### PR TITLE
Harden GitHub Actions: scope permissions, drop archived hub for gh

### DIFF
--- a/.github/workflows/setup-best-of-list.yml
+++ b/.github/workflows/setup-best-of-list.yml
@@ -9,9 +9,18 @@ env:
   SETUP_BRANCH: "setup"
   PLACEHOLDER_REPO: "best-of-lists/best-of-template"
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   setup-best-of-list:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: create-update-branch
         uses: peterjgrainger/action-create-branch@v4.0.0
@@ -24,12 +33,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.SETUP_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: setup-template
         shell: bash
+        env:
+          PLACEHOLDER_REPO: ${{ env.PLACEHOLDER_REPO }}
         run: |
-          echo $GITHUB_REPOSITORY
+          echo "$GITHUB_REPOSITORY"
           rm -rf history config latest-changes.md README.md projects.yaml ./.github/workflows/setup-best-of-list.yml CONTRIBUTING.md create-best-of-list.md
           mkdir -p ./config
           cp ./template/footer.md ./config/footer.md
@@ -37,10 +46,12 @@ jobs:
           cp ./template/projects.yaml ./projects.yaml
           cp ./template/CONTRIBUTING.md ./CONTRIBUTING.md
           rm -rf ./template/
-          sed -i 's:${{ env.PLACEHOLDER_REPO }}:'$GITHUB_REPOSITORY':g' ./config/footer.md
-          sed -i 's:${{ env.PLACEHOLDER_REPO }}:'$GITHUB_REPOSITORY':g' ./config/header.md
-          sed -i 's:${{ env.PLACEHOLDER_REPO }}:'$GITHUB_REPOSITORY':g' ./CONTRIBUTING.md
-          sed -i 's:'$(echo "${{ env.PLACEHOLDER_REPO }}" | sed "s:.*/::")':'$(echo "$GITHUB_REPOSITORY" | sed "s:.*/::")':g' ./config/header.md
+          sed -i "s:${PLACEHOLDER_REPO}:${GITHUB_REPOSITORY}:g" ./config/footer.md
+          sed -i "s:${PLACEHOLDER_REPO}:${GITHUB_REPOSITORY}:g" ./config/header.md
+          sed -i "s:${PLACEHOLDER_REPO}:${GITHUB_REPOSITORY}:g" ./CONTRIBUTING.md
+          placeholder_name="${PLACEHOLDER_REPO##*/}"
+          repo_name="${GITHUB_REPOSITORY##*/}"
+          sed -i "s:${placeholder_name}:${repo_name}:g" ./config/header.md
       - name: push-update
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
@@ -52,14 +63,18 @@ jobs:
           commit_options: "--allow-empty"
       - name: create-pull-request
         shell: bash
-        run: |
-          # Stops script execution if a command has an error
-          set -e
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.2
-          bin/hub pull-request -b ${{ env.DEFAULT_BRANCH }} -h ${{ env.SETUP_BRANCH }} --no-edit -m "Initial setup for best-of list" -m "To finish this setup: Select <code>Merge pull request</code> below and <code>Confirm merge</code>." || true
-          rm bin/hub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ env.DEFAULT_BRANCH }}
+          HEAD: ${{ env.SETUP_BRANCH }}
+        run: |
+          set -e
+          gh pr create \
+            --base "$BASE" \
+            --head "$HEAD" \
+            --title "Initial setup for best-of list" \
+            --body "To finish this setup: select **Merge pull request** below and **Confirm merge**." \
+            || true
       - name: sync-labels
         # Alternative actions:
         # https://github.com/crazy-max/ghaction-github-labeler

--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -14,22 +14,35 @@ env:
   BRANCH_PREFIX: "update/"
   DEFAULT_BRANCH: "main"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-best-of-list:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - if: ${{ github.event.inputs != null  &&  github.event.inputs.version != null }}
-        name: set-version-from-input
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-      - if: ${{ ! (env.VERSION != null && env.VERSION != '') }}
-        name: set-version-via-date
-        run: echo "VERSION=$(date '+%Y.%m.%d')" >> $GITHUB_ENV
+      - name: set-version-from-input
+        if: ${{ github.event.inputs != null && github.event.inputs.version != null && github.event.inputs.version != '' }}
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: echo "VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
+      - name: set-version-via-date
+        if: ${{ ! (env.VERSION != null && env.VERSION != '') }}
+        run: echo "VERSION=$(date '+%Y.%m.%d')" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
       - name: check-version-tag
         shell: bash
+        env:
+          VERSION: ${{ env.VERSION }}
         run: |
           git fetch --tags --force
-          git show-ref --tags --verify --quiet -- "refs/tags/${{ env.VERSION }}" && echo "VERSION=$(date '+%Y.%m.%d-%H.%M')" >> $GITHUB_ENV || exit 0
+          if git show-ref --tags --verify --quiet -- "refs/tags/$VERSION"; then
+            echo "VERSION=$(date '+%Y.%m.%d-%H.%M')" >> "$GITHUB_ENV"
+          fi
       - name: create-update-branch
         uses: peterjgrainger/action-create-branch@v4.0.0
         env:
@@ -41,8 +54,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.BRANCH_PREFIX }}${{ env.VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: update-best-of-list
         uses: best-of-lists/best-of-update-action@v0.8.5
         with:
@@ -51,30 +62,35 @@ jobs:
       - name: push-update
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          branch: ${{ env.BRANCH_PREFIX }}${{ env.VERSION  }}
+          branch: ${{ env.BRANCH_PREFIX }}${{ env.VERSION }}
           commit_user_name: best-of update
           commit_user_email: actions@github.com
-          commit_message: Update best-of list for version ${{ env.VERSION  }}
-          tagging_message: ${{ env.VERSION  }}
+          commit_message: Update best-of list for version ${{ env.VERSION }}
+          tagging_message: ${{ env.VERSION }}
           skip_dirty_check: true
           commit_options: "--allow-empty"
       - name: create-pull-request
         shell: bash
-        run: |
-          # Stops script execution if a command has an error
-          set -e
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.2
-          bin/hub pull-request -b ${{ env.DEFAULT_BRANCH }} -h ${{ env.BRANCH_PREFIX }}${{ env.VERSION  }} --no-edit -m "Best-of update: ${{ env.VERSION  }}" -m "To finish this update: Select <code>Merge pull request</code> below and <code>Confirm merge</code>. Also, make sure to publish the created draft release in the [releases section](../releases) as well." || true
-          rm bin/hub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ env.DEFAULT_BRANCH }}
+          HEAD: ${{ env.BRANCH_PREFIX }}${{ env.VERSION }}
+          VERSION: ${{ env.VERSION }}
+        run: |
+          set -e
+          gh pr create \
+            --base "$BASE" \
+            --head "$HEAD" \
+            --title "Best-of update: $VERSION" \
+            --body "To finish this update: select **Merge pull request** below and **Confirm merge**. Also publish the created draft release in the [releases section](../releases)." \
+            || true
       - name: create-release
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.VERSION  }}
-          name: "Update: ${{ env.VERSION  }}"
+          tag_name: ${{ env.VERSION }}
+          name: "Update: ${{ env.VERSION }}"
           body_path: "latest-changes.md"
           draft: true
           prerelease: false


### PR DESCRIPTION
## Summary

- Add scoped `permissions:` blocks (workflow + job level) to both workflows so the `GITHUB_TOKEN` no longer relies on the implicit org/repo default — least privilege.
- Replace the `curl … github.com/github/hub/raw/master/script/get | bash` bootstrap + `bin/hub pull-request` with `gh pr create` (the `gh` CLI is preinstalled on GitHub-hosted runners). Removes a supply-chain hop through the archived `github/hub` repo's `master` branch.
- Route `workflow_dispatch` input and env values through `env:` mappings so they're quoted in the shell rather than interpolated as raw template strings (mitigates the standard Actions template-injection class).

Behavior unchanged: same branches created, same commits/tags pushed, same draft release published.

## Test plan

- [x] Both workflow YAMLs validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] Manual `workflow_dispatch` of `update-best-of-list` after merge to verify the `gh pr create` path produces the expected update PR.

https://claude.ai/code/session_01L1w9cSCBStkLcEuU2k1jwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1w9cSCBStkLcEuU2k1jwA)_