### PR TITLE
Add one-shot cron to merge PR #6 at 2026-05-05 05:05 UTC

### DIFF
--- a/.github/workflows/relabel-axis-merge-once.yml
+++ b/.github/workflows/relabel-axis-merge-once.yml
@@ -1,0 +1,67 @@
+# One-shot scheduled workflow: at 05:05 UTC on 2026-05-05, merge PR #6
+# (the axis-tier rebrand) into main and then delete this workflow file.
+#
+# After the workflow runs once successfully, it removes itself from main
+# in the same job, so the cron schedule effectively never fires again.
+# If the PR is already merged or closed when the cron runs, the merge step
+# is skipped and the workflow still self-deletes.
+#
+# `workflow_dispatch` is enabled so the merge can be triggered manually
+# without waiting for the schedule (or to retry if a run fails).
+
+name: relabel-axis-merge-once
+
+on:
+  schedule:
+    # minute hour day-of-month month day-of-week
+    - cron: "5 5 5 5 *"   # 2026-05-05 05:05 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-and-self-delete:
+    runs-on: ubuntu-latest
+    if: github.repository == 'RyanAlberts/best-of-Agent-Harnesses'
+    env:
+      TARGET_PR: "6"
+      WORKFLOW_FILE: ".github/workflows/relabel-axis-merge-once.yml"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge PR if still open
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          state=$(gh pr view "$TARGET_PR" --json state --jq .state)
+          echo "PR #$TARGET_PR state: $state"
+          if [ "$state" = "OPEN" ]; then
+            gh pr merge "$TARGET_PR" --merge
+          else
+            echo "PR not open — skipping merge."
+          fi
+
+      - name: Self-delete this workflow from main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "Ryan Alexander Alberts"
+          git config user.email "ryan.a.alberts@gmail.com"
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+          if [ -f "$WORKFLOW_FILE" ]; then
+            git rm "$WORKFLOW_FILE"
+            git commit --author="Ryan Alexander Alberts <ryan.a.alberts@gmail.com>" \
+              -m "Remove one-shot relabel-axis-merge cron after successful run"
+            git push origin main
+          else
+            echo "Workflow file already removed — nothing to do."
+          fi


### PR DESCRIPTION
## Summary

Adds a single one-shot scheduled workflow that fires at **2026-05-05 05:05 UTC** (~90 minutes after authoring) and:

1. Runs `gh pr merge 6 --merge` to land [#6](https://github.com/RyanAlberts/best-of-Agent-Harnesses/pull/6) (the axis-tier rebrand). If the PR is already closed/merged when the cron fires, the merge step is skipped.
2. Commits the removal of this workflow file back to `main` so the cron never fires again.

`workflow_dispatch` is enabled for manual fire-now / retry from the Actions tab.

GitHub Actions schedules can drift 5–15 min under load — treat **05:05–05:25 UTC** as the merge window.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(open(...))"`).
- [x] Cron syntax `5 5 5 5 *` confirmed via crontab.guru semantics: minute=5, hour=5, day-of-month=5, month=5.
- [x] `if: github.repository == 'RyanAlberts/best-of-Agent-Harnesses'` guards against accidental fork runs.
- [ ] (post-merge) Workflow shows up in the Actions tab; manually verify schedule by checking the `Next run` field.

This PR needs to be merged into `main` *before* 05:05 UTC for the schedule to take effect — GitHub only honors `schedule:` triggers from workflows present on the default branch.

https://claude.ai/code/session_01L1w9cSCBStkLcEuU2k1jwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1w9cSCBStkLcEuU2k1jwA)_