### PR TITLE
Add project: LocalHarness

### DIFF
--- a/harnesses.json
+++ b/harnesses.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses",
     "license": "CC-BY-SA-4.0",
     "stars_captured": "2026-06-14",
-    "project_count": 110,
+    "project_count": 111,
     "tiers": [
       "super simple",
       "mostly simple",
@@ -1732,6 +1732,32 @@
       "example": {
         "label": "Parallel marketing agents",
         "url": "https://github.com/superagentxai/superagentx/blob/master/examples/agents/parallel_agents.py"
+      }
+    },
+    {
+      "name": "LocalHarness",
+      "github_id": "ahwurm/localharness",
+      "url": "https://github.com/ahwurm/localharness",
+      "description": "Model-agnostic, config-driven (YAML) agent harness built for local LLMs (vLLM/Ollama/LM Studio/llama.cpp); orchestrator → divisions → agents with isolated per-agent memory, deny-first permissions, an event-bus audit trail, and a built-in benchmark for measuring harness changes against your own model.",
+      "category": "frameworks",
+      "category_title": "Frameworks",
+      "stars": 6,
+      "tier": "slightly complex",
+      "tier_rank": 3,
+      "axis": "moderate (YAML-config agent org: orchestrator→divisions→agents; built-in bench + autoresearch loop)",
+      "autonomy": "bounded",
+      "autonomy_rank": 3,
+      "recovery": "retry",
+      "recovery_rank": 2,
+      "license_signal": "open-source",
+      "tags": [
+        "local",
+        "yaml",
+        "python"
+      ],
+      "example": {
+        "label": "Quickstart: init + start",
+        "url": "https://github.com/ahwurm/localharness#quick-start"
       }
     },
     {

--- a/projects.yaml
+++ b/projects.yaml
@@ -181,6 +181,10 @@ projects:
     labels: ["python"]
     category: "personal-agent-runtimes"
   # Frameworks
+  - name: LocalHarness
+    github_id: ahwurm/localharness
+    labels: ["python"]
+    category: "frameworks"
   - name: langgraph
     github_id: langchain-ai/langgraph
     labels: ["python"]


### PR DESCRIPTION
Adds **LocalHarness** (ahwurm/localharness) under the `frameworks` category.

LocalHarness is an open-source (MIT), model-agnostic, config-driven agent harness built for local LLMs — the agent layer on top of vLLM / Ollama / LM Studio / llama.cpp. Agents are defined in YAML and run as a coordinated org (orchestrator → divisions → agents), with isolated per-agent memory, deny-first permissions, and a built-in benchmark for measuring harness changes against your own model.

Added to `projects.yaml` (not the README), per CONTRIBUTING. Not previously listed.