### PR TITLE
Add project: TeamCopilot

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -116,6 +116,10 @@ projects:
     github_id: openinterpreter/openinterpreter
     labels: ["python"]
     category: "coding-agent-products"
+  - name: TeamCopilot
+    github_id: rishabhpoddar/teamcopilot
+    labels: ["javascript", "python"]
+    category: "coding-agent-products"
   # Coding harness configs and SDKs
   - name: get-shit-done
     github_id: gsd-build/get-shit-done


### PR DESCRIPTION
Adds **TeamCopilot** to the list.

- **Repo:** https://github.com/rishabhpoddar/teamcopilot
- **Category:** coding-agent-products
- **Labels:** javascript, python

TeamCopilot is an open-source, self-hostable multi-user AI agent platform for teams. It's a full suite (web UI + embedded OpenCode-based agent execution) with approval/permission controls, audit trails for chat sessions and file changes, a shared filesystem-backed workspace of skills and workflows, and team-oriented secret management.

Only `projects.yaml` is modified, as per the contributing guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)