### PR TITLE
Add project: oh-my-pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <a href="https://best-of.org" title="Best-of Badge"><img src="http://bit.ly/3o3EHNN"></a>
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-110-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-111-blue.svg?color=5ac4bf"></a>
     <a href="https://ryanalberts.github.io/best-of-Agent-Harnesses/" title="Browse the searchable site"><img src="https://img.shields.io/badge/website-live-5ac4bf.svg"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/releases" title="Updates"><img src="https://img.shields.io/github/release-date/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
@@ -89,7 +89,7 @@ claude mcp add agent-harnesses -- uvx agent-harnesses-mcp
 - [For agents: harnesses.json, llms.txt, MCP server](#for-agents)
 - [FAQ](#faq)
 - [Progressive disclosure harnesses](#progressive-disclosure-harnesses) _7 projects_
-- [Coding agent products (IDEs, CLIs, full suites)](#coding-agent-products-ides-clis-full-suites) _11 projects_
+- [Coding agent products (IDEs, CLIs, full suites)](#coding-agent-products-ides-clis-full-suites) _12 projects_
 - [Coding harness configs and SDKs](#coding-harness-configs-and-sdks) _10 projects_
 - [Personal agent runtimes](#personal-agent-runtimes) _7 projects_
 - [Frameworks](#frameworks) _23 projects_
@@ -146,8 +146,9 @@ _Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Docke
 | 7 | <a name="goose"></a>[**goose**](https://github.com/aaif-goose/goose)&#8202;★ | [50.2k](https://github.com/aaif-goose/goose/stargazers) | Block-originated Rust agent, now stewarded by the Linux Foundation's Agentic AI Foundation (`aaif-goose/goose`). The **harness** is the MCP/ACP extension model with recipes and provider choice; there's no fixed UI slot—you bolt it into whatever shell you use. <sup>`mcp` · `rust`</sup> | ✅ | slightly complex (extensions, MCP/ACP) | [Goose recipes guide](https://block.github.io/goose/docs/guides/recipes/) |
 | 8 | <a name="crush"></a>[**crush**](https://github.com/charmbracelet/crush) | [25.8k](https://github.com/charmbracelet/crush/stargazers) | Charm's terminal coding agent (Charm's fork of the original OpenCode). The **harness** is the tool-calling loop with session persistence; the Bubble Tea TUI is the shell. <sup>`memory` · `cli` · `tui`</sup> | ⚠️ FSL-1.1-MIT | slightly complex (terminal agent, TUI) | [Crush launch post](https://charm.land/blog/crush-comes-home/) |
 | 9 | <a name="roo-code"></a>[**Roo Code**](https://github.com/RooCodeInc/Roo-Code) | [24.3k](https://github.com/RooCodeInc/Roo-Code/stargazers) | VS Code/Cursor extension in the Cline lineage. The **harness** is the approval-gated agent with custom modes and a strong MCP story; the IDE is the UI. Popular community fork when you want that workflow without the upstream extension. <sup>`mcp` · `workflow` · `ide` · `typescript`</sup> | ✅ | slightly complex (IDE extension, MCP-first) | [Custom modes guide](https://docs.roocode.com/features/custom-modes) |
-| 10 | <a name="claw-code-agent"></a>[**claw-code-agent**](https://github.com/HarnessLab/claw-code-agent) | [519](https://github.com/HarnessLab/claw-code-agent/stargazers) | Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. <sup>`mcp` · `rust` · `python` · `typescript`</sup> | ❓ | slightly complex (pure Python, plugin runtime) | [Quick Start guide](https://github.com/HarnessLab/claw-code-agent#-quick-start) |
-| 11 | <a name="builderforceagents"></a>[**coderClaw**](https://github.com/SeanHogg/BuilderForceAgents) | [3](https://github.com/SeanHogg/BuilderForceAgents/stargazers) | Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers. <sup>`ide` · `typescript`</sup> | ❓ | slightly complex (multi-role, AST/semantic) | [Multi-agent README](https://github.com/SeanHogg/BuilderForceAgents#readme) |
+| 10 | <a name="oh-my-pi"></a>[**oh-my-pi**](https://github.com/can1357/oh-my-pi) | [14.9k](https://github.com/can1357/oh-my-pi/stargazers) | Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core. <sup>`browser` · `provider-agnostic` · `cli` · `ide` · `rust`</sup> | ✅ | slightly complex (terminal agent, LSP/DAP, multi-provider) | [LSP wired into edits](https://github.com/can1357/oh-my-pi/blob/main/docs/lsp-config.md) |
+| 11 | <a name="claw-code-agent"></a>[**claw-code-agent**](https://github.com/HarnessLab/claw-code-agent) | [519](https://github.com/HarnessLab/claw-code-agent/stargazers) | Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. <sup>`mcp` · `rust` · `python` · `typescript`</sup> | ❓ | slightly complex (pure Python, plugin runtime) | [Quick Start guide](https://github.com/HarnessLab/claw-code-agent#-quick-start) |
+| 12 | <a name="builderforceagents"></a>[**coderClaw**](https://github.com/SeanHogg/BuilderForceAgents) | [3](https://github.com/SeanHogg/BuilderForceAgents/stargazers) | Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers. <sup>`ide` · `typescript`</sup> | ❓ | slightly complex (multi-role, AST/semantic) | [Multi-agent README](https://github.com/SeanHogg/BuilderForceAgents#readme) |
 
 ## Coding harness configs and SDKs
 
@@ -325,7 +326,7 @@ Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n
 
 ### How many of these agent harnesses are open source?
 
-96 of 110 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+97 of 111 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable -->
 # Tags — cross-reference
 
-_Auto-generated from `scripts/generate.py`. 110 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
+_Auto-generated from `scripts/generate.py`. 111 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
 
 Tag chips appear next to each project in [README.md](README.md). This page lists every tag once with the projects that carry it, grouped by category and sorted by GitHub stars within each category.
 
 ## All tags
 
-[`mcp`](#mcp) (21) · [`memory`](#memory) (18) · [`multi-agent`](#multi-agent) (19) · [`evals`](#evals) (14) · [`voice`](#voice) (2) · [`vision`](#vision) (2) · [`browser`](#browser) (4) · [`sandbox`](#sandbox) (17) · [`low-code`](#low-code) (4) · [`rag`](#rag) (4) · [`tool-discovery`](#tool-discovery) (6) · [`training`](#training) (4) · [`workflow`](#workflow) (7) · [`typed`](#typed) (3) · [`local`](#local) (1) · [`provider-agnostic`](#provider-agnostic) (8) · [`cli`](#cli) (9) · [`ide`](#ide) (6) · [`tui`](#tui) (2) · [`rust`](#rust) (2) · [`python`](#python) (62) · [`typescript`](#typescript) (27)
+[`mcp`](#mcp) (21) · [`memory`](#memory) (18) · [`multi-agent`](#multi-agent) (19) · [`evals`](#evals) (14) · [`voice`](#voice) (2) · [`vision`](#vision) (2) · [`browser`](#browser) (5) · [`sandbox`](#sandbox) (17) · [`low-code`](#low-code) (4) · [`rag`](#rag) (4) · [`tool-discovery`](#tool-discovery) (6) · [`training`](#training) (4) · [`workflow`](#workflow) (7) · [`typed`](#typed) (3) · [`local`](#local) (1) · [`provider-agnostic`](#provider-agnostic) (9) · [`cli`](#cli) (10) · [`ide`](#ide) (7) · [`tui`](#tui) (2) · [`rust`](#rust) (3) · [`python`](#python) (63) · [`typescript`](#typescript) (28)
 
 ---
 
@@ -194,6 +194,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 **Coding agent products (IDEs, CLIs, full suites)**
 
 - [OpenHands](https://github.com/OpenHands/OpenHands) — ⭐78.4k — Dockerized software-engineering agent. The **harness** is the bash/editor/browser toolset with micro-agents and event-stream session bridging; Docker is the sandbox. Main OSS choice for teams self-hosting autonomous repo work.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 
 **Personal agent runtimes**
 
@@ -356,6 +357,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 
 - [opencode](https://github.com/anomalyco/opencode) — ⭐179k — Open-source terminal coding agent (formerly `sst/opencode`; transferred to anomalyco). The **harness** is a multi-provider tool-call loop (Claude, OpenAI, Gemini, local) with strong plugin and MCP support; the TUI is the shell. 100% OSS, very actively shipped.
 - [Codex](https://github.com/openai/codex) — ⭐93.9k — OpenAI's terminal coding agent. The **harness** is the sandboxed tool-call loop with multi-provider support; the CLI is the shell. Reference implementation for "official CLI that ships code."
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 
 **Coding harness configs and SDKs**
 
@@ -386,6 +388,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Codex](https://github.com/openai/codex) — ⭐93.9k — OpenAI's terminal coding agent. The **harness** is the sandboxed tool-call loop with multi-provider support; the CLI is the shell. Reference implementation for "official CLI that ships code."
 - [Open Interpreter](https://github.com/openinterpreter/openinterpreter) — ⭐64.1k — Lightweight terminal coding agent oriented to open models (DeepSeek, Kimi, Qwen). The **harness** is a code-execution loop — the model writes code, the harness executes it with confirmation gates; the CLI is the shell. The original "let the LLM run code on my machine" project, reborn for open weights.
 - [crush](https://github.com/charmbracelet/crush) — ⭐25.8k — Charm's terminal coding agent (Charm's fork of the original OpenCode). The **harness** is the tool-calling loop with session persistence; the Bubble Tea TUI is the shell.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 
 **Coding harness configs and SDKs**
 
@@ -409,6 +412,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 
 - [Cline](https://github.com/cline/cline) — ⭐63.9k — VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.
 - [Roo Code](https://github.com/RooCodeInc/Roo-Code) — ⭐24.3k — VS Code/Cursor extension in the Cline lineage. The **harness** is the approval-gated agent with custom modes and a strong MCP story; the IDE is the UI. Popular community fork when you want that workflow without the upstream extension.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 - [coderClaw](https://github.com/SeanHogg/BuilderForceAgents) — ⭐3 — Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers.
 
 **Coding harness configs and SDKs**
@@ -435,6 +439,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 **Coding agent products (IDEs, CLIs, full suites)**
 
 - [goose](https://github.com/aaif-goose/goose) — ⭐50.2k — Block-originated Rust agent, now stewarded by the Linux Foundation's Agentic AI Foundation (`aaif-goose/goose`). The **harness** is the MCP/ACP extension model with recipes and provider choice; there's no fixed UI slot—you bolt it into whatever shell you use.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐519 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 
 ---
@@ -450,6 +455,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 
 - [OpenHands](https://github.com/OpenHands/OpenHands) — ⭐78.4k — Dockerized software-engineering agent. The **harness** is the bash/editor/browser toolset with micro-agents and event-stream session bridging; Docker is the sandbox. Main OSS choice for teams self-hosting autonomous repo work.
 - [Open Interpreter](https://github.com/openinterpreter/openinterpreter) — ⭐64.1k — Lightweight terminal coding agent oriented to open models (DeepSeek, Kimi, Qwen). The **harness** is a code-execution loop — the model writes code, the harness executes it with confirmation gates; the CLI is the shell. The original "let the LLM run code on my machine" project, reborn for open weights.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐519 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 
 **Coding harness configs and SDKs**
@@ -547,6 +553,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — ⭐106k — Google's first-party terminal agent for Gemini. The **harness** is the plugin/MCP tool-call loop; the terminal is the shell—Google's parallel to Claude Code / Codex, not just an API.
 - [Cline](https://github.com/cline/cline) — ⭐63.9k — VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.
 - [Roo Code](https://github.com/RooCodeInc/Roo-Code) — ⭐24.3k — VS Code/Cursor extension in the Cline lineage. The **harness** is the approval-gated agent with custom modes and a strong MCP story; the IDE is the UI. Popular community fork when you want that workflow without the upstream extension.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐519 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 - [coderClaw](https://github.com/SeanHogg/BuilderForceAgents) — ⭐3 — Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers.
 
@@ -598,6 +605,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 
 - [OpenHands](https://github.com/OpenHands/OpenHands) — ⭐78.4k — Dockerized software-engineering agent. The **harness** is the bash/editor/browser toolset with micro-agents and event-stream session bridging; Docker is the sandbox. Main OSS choice for teams self-hosting autonomous repo work.
 - [Open Interpreter](https://github.com/openinterpreter/openinterpreter) — ⭐64.1k — Lightweight terminal coding agent oriented to open models (DeepSeek, Kimi, Qwen). The **harness** is a code-execution loop — the model writes code, the harness executes it with confirmation gates; the CLI is the shell. The original "let the LLM run code on my machine" project, reborn for open weights.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐519 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 
 **Coding harness configs and SDKs**
@@ -695,6 +703,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — ⭐106k — Google's first-party terminal agent for Gemini. The **harness** is the plugin/MCP tool-call loop; the terminal is the shell—Google's parallel to Claude Code / Codex, not just an API.
 - [Cline](https://github.com/cline/cline) — ⭐63.9k — VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.
 - [Roo Code](https://github.com/RooCodeInc/Roo-Code) — ⭐24.3k — VS Code/Cursor extension in the Cline lineage. The **harness** is the approval-gated agent with custom modes and a strong MCP story; the IDE is the UI. Popular community fork when you want that workflow without the upstream extension.
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k — Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐519 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 - [coderClaw](https://github.com/SeanHogg/BuilderForceAgents) — ⭐3 — Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers.
 

--- a/assets/axes-grid.svg
+++ b/assets/axes-grid.svg
@@ -26,7 +26,7 @@
 <text x="832.5" y="652.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">9</text>
 <text x="832.5" y="254.5" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">4</text>
 <text x="397.5" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">2</text>
-<text x="832.5" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">16</text>
+<text x="832.5" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">17</text>
 <text x="1050.0" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">20</text>
 <text x="615.0" y="652.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">1</text>
 <text x="1050.0" y="652.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">12</text>
@@ -71,6 +71,7 @@
 <circle cx="717.6" cy="309.0" r="5.5" fill="#ec4899" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Microsoft Agent Framework — ⭐11.7k</title></circle>
 <circle cx="799.2" cy="350.0" r="5.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>OpenHarness (HKUDS) — ⭐14.2k</title></circle>
 <circle cx="951.6" cy="357.8" r="5.5" fill="#3b82f6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>botpress — ⭐14.8k</title></circle>
+<circle cx="722.3" cy="360.9" r="5.5" fill="#ef4444" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>oh-my-pi — ⭐14.9k</title></circle>
 <circle cx="944.9" cy="330.8" r="5.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Agent Lightning — ⭐17.3k</title></circle>
 <circle cx="693.4" cy="176.4" r="5.5" fill="#a16207" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>pydantic-ai — ⭐18k</title></circle>
 <circle cx="788.7" cy="302.8" r="5.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Agent Zero — ⭐18.2k</title></circle>
@@ -126,5 +127,5 @@
 <text x="767.1" y="501.0" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">langchain</text>
 <text x="1004.2" y="448.5" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">langflow</text>
 <text x="534.2" y="313.2" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">aider</text>
-<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">81 loop-owning projects shown · 29 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
+<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">82 loop-owning projects shown · 29 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
 </svg>

--- a/assets/landscape.svg
+++ b/assets/landscape.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 880" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
 <rect width="1320" height="880" fill="#ffffff" rx="8"/>
 <text x="660.0" y="52" text-anchor="middle" font-size="30" font-weight="700" fill="#111827">The Agent Harness Landscape</text>
-<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">110 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-06-26</text>
+<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">111 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-06-26</text>
 <circle cx="80" cy="106" r="6" fill="#8b5cf6"/>
 <text x="91" y="110" font-size="12.5" fill="#374151">Progressive disclosure</text>
 <circle cx="262.2" cy="106" r="6" fill="#ef4444"/>
@@ -40,7 +40,7 @@
 <text x="533.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">19 projects</text>
 <line x1="685.0" y1="168" x2="685.0" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="836.2" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">slightly complex</text>
-<text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">43 projects</text>
+<text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">44 projects</text>
 <line x1="987.5" y1="168" x2="987.5" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="1138.8" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">complex</text>
 <text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">39 projects</text>
@@ -99,6 +99,7 @@
 <circle cx="830.1" cy="315.8" r="4.5" fill="#a16207" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>E2B — ⭐12.7k</title></circle>
 <circle cx="1222.0" cy="310.4" r="4.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>OpenHarness (HKUDS) — ⭐14.2k</title></circle>
 <circle cx="1139.1" cy="308.5" r="4.5" fill="#3b82f6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>botpress — ⭐14.8k</title></circle>
+<circle cx="821.7" cy="307.9" r="4.5" fill="#ef4444" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>oh-my-pi — ⭐14.9k</title></circle>
 <circle cx="1130.6" cy="300.5" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Agent Lightning — ⭐17.3k</title></circle>
 <circle cx="784.9" cy="298.6" r="4.5" fill="#a16207" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>pydantic-ai — ⭐18k</title></circle>
 <circle cx="906.1" cy="298.0" r="4.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Agent Zero — ⭐18.2k</title></circle>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -5,6 +5,6 @@
   <text x="140" y="184" font-family="Helvetica,Arial,sans-serif" font-size="32" fill="#5ac4bf" font-weight="700">best-of-Agent-Harnesses</text>
   <text x="80" y="300" font-family="Helvetica,Arial,sans-serif" font-size="74" fill="#f0f6fc" font-weight="800">Best of Agent Harnesses</text>
   <text x="80" y="378" font-family="Helvetica,Arial,sans-serif" font-size="38" fill="#9ca3af">The runtimes that close the loop between a model and the world.</text>
-  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">110 harnesses · 10 categories · MCP-ready · weekly-rescored</text>
+  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">111 harnesses · 10 categories · MCP-ready · weekly-rescored</text>
   <text x="80" y="566" font-family="Helvetica,Arial,sans-serif" font-size="27" fill="#9ca3af">github.com/RyanAlberts/best-of-Agent-Harnesses</text>
 </svg>

--- a/config/header.md
+++ b/config/header.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <a href="https://best-of.org" title="Best-of Badge"><img src="http://bit.ly/3o3EHNN"></a>
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-110-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-111-blue.svg?color=5ac4bf"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/releases" title="Updates"><img src="https://img.shields.io/github/release-date/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
 </p>

--- a/feed.json
+++ b/feed.json
@@ -16,7 +16,7 @@
       "title": "Agent Harnesses list refreshed — 2026-06-26",
       "url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses",
       "date_published": "2026-06-26T00:00:00Z",
-      "content_text": "110 harnesses across 10 categories. Stars captured 2026-06-26. Most-starred: awesome-cursorrules, agents.md, langgraph-bigtool, MCP-Zero, ToolGen."
+      "content_text": "111 harnesses across 10 categories. Stars captured 2026-06-26. Most-starred: awesome-cursorrules, agents.md, langgraph-bigtool, MCP-Zero, ToolGen."
     },
     {
       "id": "refresh-2026-06-21",

--- a/harnesses.json
+++ b/harnesses.json
@@ -9,7 +9,7 @@
     "feed_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/feed.json",
     "license": "CC-BY-SA-4.0",
     "stars_captured": "2026-06-26",
-    "project_count": 110,
+    "project_count": 111,
     "tiers": [
       "super simple",
       "mostly simple",
@@ -336,7 +336,7 @@
     {
       "kind": "derived",
       "q": "How many of these agent harnesses are open source?",
-      "a": "96 of 110 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
+      "a": "97 of 111 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
       "slug": "how-many-of-these-agent-harnesses-are-open-source"
     },
     {
@@ -848,6 +848,39 @@
       "example": {
         "label": "Custom modes guide",
         "url": "https://docs.roocode.com/features/custom-modes"
+      }
+    },
+    {
+      "name": "oh-my-pi",
+      "github_id": "can1357/oh-my-pi",
+      "url": "https://github.com/can1357/oh-my-pi",
+      "slug": "oh-my-pi",
+      "anchor_url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses#oh-my-pi",
+      "page_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/h/oh-my-pi/",
+      "description": "Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.",
+      "category": "coding-agent-products",
+      "category_title": "Coding agent products (IDEs, CLIs, full suites)",
+      "stars": 14939,
+      "tier": "slightly complex",
+      "tier_rank": 3,
+      "axis": "slightly complex (terminal agent, LSP/DAP, multi-provider)",
+      "autonomy": "bounded",
+      "autonomy_rank": 3,
+      "recovery": "resumable",
+      "recovery_rank": 3,
+      "license_signal": "open-source",
+      "tags": [
+        "browser",
+        "provider-agnostic",
+        "cli",
+        "ide",
+        "rust",
+        "python",
+        "typescript"
+      ],
+      "example": {
+        "label": "LSP wired into edits",
+        "url": "https://github.com/can1357/oh-my-pi/blob/main/docs/lsp-config.md"
       }
     },
     {

--- a/harnesses.jsonld
+++ b/harnesses.jsonld
@@ -29,7 +29,7 @@
   ],
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": 110,
+    "numberOfItems": 111,
     "itemListElement": [
       {
         "@type": "ListItem",
@@ -228,6 +228,18 @@
         "position": 17,
         "item": {
           "@type": "SoftwareApplication",
+          "name": "oh-my-pi",
+          "url": "https://github.com/can1357/oh-my-pi",
+          "description": "Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.",
+          "applicationCategory": "DeveloperApplication",
+          "keywords": "browser, provider-agnostic, cli, ide, rust, python, typescript"
+        }
+      },
+      {
+        "@type": "ListItem",
+        "position": 18,
+        "item": {
+          "@type": "SoftwareApplication",
           "name": "claw-code-agent",
           "url": "https://github.com/HarnessLab/claw-code-agent",
           "description": "Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.",
@@ -237,7 +249,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 18,
+        "position": 19,
         "item": {
           "@type": "SoftwareApplication",
           "name": "coderClaw",
@@ -249,7 +261,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 19,
+        "position": 20,
         "item": {
           "@type": "SoftwareApplication",
           "name": "superpowers",
@@ -261,7 +273,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 20,
+        "position": 21,
         "item": {
           "@type": "SoftwareApplication",
           "name": "everything-claude-code",
@@ -273,7 +285,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 21,
+        "position": 22,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Anthropic Skills",
@@ -285,7 +297,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 22,
+        "position": 23,
         "item": {
           "@type": "SoftwareApplication",
           "name": "GStack",
@@ -297,7 +309,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 23,
+        "position": 24,
         "item": {
           "@type": "SoftwareApplication",
           "name": "get-shit-done",
@@ -309,7 +321,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 24,
+        "position": 25,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-agent",
@@ -321,7 +333,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 25,
+        "position": 26,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Claude Agent SDK",
@@ -333,7 +345,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 26,
+        "position": 27,
         "item": {
           "@type": "SoftwareApplication",
           "name": "RepoMaster",
@@ -345,7 +357,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 27,
+        "position": 28,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoHarness",
@@ -357,7 +369,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 28,
+        "position": 29,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pmstack",
@@ -369,7 +381,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 29,
+        "position": 30,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenClaw",
@@ -381,7 +393,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 30,
+        "position": 31,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Hermes",
@@ -393,7 +405,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 31,
+        "position": 32,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Khoj",
@@ -405,7 +417,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 32,
+        "position": 33,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Eliza",
@@ -417,7 +429,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 33,
+        "position": 34,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Zero",
@@ -429,7 +441,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 34,
+        "position": 35,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenHarness (HKUDS)",
@@ -441,7 +453,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 35,
+        "position": 36,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AIlice",
@@ -453,7 +465,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 36,
+        "position": 37,
         "item": {
           "@type": "SoftwareApplication",
           "name": "n8n",
@@ -465,7 +477,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 37,
+        "position": 38,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoGPT",
@@ -477,7 +489,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 38,
+        "position": 39,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langflow",
@@ -489,7 +501,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 39,
+        "position": 40,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Dify",
@@ -501,7 +513,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 40,
+        "position": 41,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langchain",
@@ -513,7 +525,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 41,
+        "position": 42,
         "item": {
           "@type": "SoftwareApplication",
           "name": "browser-use",
@@ -525,7 +537,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 42,
+        "position": 43,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Flowise",
@@ -537,7 +549,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 43,
+        "position": 44,
         "item": {
           "@type": "SoftwareApplication",
           "name": "llama-index",
@@ -549,7 +561,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 44,
+        "position": 45,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agno",
@@ -561,7 +573,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 45,
+        "position": 46,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langgraph",
@@ -573,7 +585,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 46,
+        "position": 47,
         "item": {
           "@type": "SoftwareApplication",
           "name": "semantic-kernel",
@@ -585,7 +597,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 47,
+        "position": 48,
         "item": {
           "@type": "SoftwareApplication",
           "name": "mastra",
@@ -597,7 +609,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 48,
+        "position": 49,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta",
@@ -609,7 +621,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 49,
+        "position": 50,
         "item": {
           "@type": "SoftwareApplication",
           "name": "rasa",
@@ -621,7 +633,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 50,
+        "position": 51,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Google ADK",
@@ -633,7 +645,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 51,
+        "position": 52,
         "item": {
           "@type": "SoftwareApplication",
           "name": "botpress",
@@ -645,7 +657,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 52,
+        "position": 53,
         "item": {
           "@type": "SoftwareApplication",
           "name": "R2R",
@@ -657,7 +669,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 53,
+        "position": 54,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-squad",
@@ -669,7 +681,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 54,
+        "position": 55,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentVerse",
@@ -681,7 +693,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 55,
+        "position": 56,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Bee Agent Framework",
@@ -693,7 +705,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 56,
+        "position": 57,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentStack",
@@ -705,7 +717,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 57,
+        "position": 58,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentSilex",
@@ -717,7 +729,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 58,
+        "position": 59,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SuperAgentX",
@@ -729,7 +741,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 59,
+        "position": 60,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MetaGPT",
@@ -741,7 +753,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 60,
+        "position": 61,
         "item": {
           "@type": "SoftwareApplication",
           "name": "autogen",
@@ -753,7 +765,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 61,
+        "position": 62,
         "item": {
           "@type": "SoftwareApplication",
           "name": "crewAI",
@@ -765,7 +777,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 62,
+        "position": 63,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ChatDev",
@@ -777,7 +789,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 63,
+        "position": 64,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-python",
@@ -789,7 +801,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 64,
+        "position": 65,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Microsoft Agent Framework",
@@ -801,7 +813,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 65,
+        "position": 66,
         "item": {
           "@type": "SoftwareApplication",
           "name": "PraisonAI",
@@ -813,7 +825,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 66,
+        "position": 67,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentRL",
@@ -825,7 +837,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 67,
+        "position": 68,
         "item": {
           "@type": "SoftwareApplication",
           "name": "claude-mem",
@@ -837,7 +849,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 68,
+        "position": 69,
         "item": {
           "@type": "SoftwareApplication",
           "name": "aider",
@@ -849,7 +861,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 69,
+        "position": 70,
         "item": {
           "@type": "SoftwareApplication",
           "name": "continue",
@@ -861,7 +873,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 70,
+        "position": 71,
         "item": {
           "@type": "SoftwareApplication",
           "name": "github-mcp-server",
@@ -873,7 +885,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 71,
+        "position": 72,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Python SDK",
@@ -885,7 +897,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 72,
+        "position": 73,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP TypeScript SDK",
@@ -897,7 +909,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 73,
+        "position": 74,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Inspector",
@@ -909,7 +921,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 74,
+        "position": 75,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Registry",
@@ -921,7 +933,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 75,
+        "position": 76,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Docker MCP Gateway",
@@ -933,7 +945,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 76,
+        "position": 77,
         "item": {
           "@type": "SoftwareApplication",
           "name": "puppeteer-real-browser-mcp",
@@ -945,7 +957,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 77,
+        "position": 78,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Better-OpenCodeMCP",
@@ -957,7 +969,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 78,
+        "position": 79,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agentlog",
@@ -969,7 +981,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 79,
+        "position": 80,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Lightning",
@@ -981,7 +993,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 80,
+        "position": 81,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-bench",
@@ -993,7 +1005,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 81,
+        "position": 82,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentBench",
@@ -1005,7 +1017,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 82,
+        "position": 83,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_ai",
@@ -1017,7 +1029,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 83,
+        "position": 84,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebArena",
@@ -1029,7 +1041,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 84,
+        "position": 85,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebVoyager",
@@ -1041,7 +1053,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 85,
+        "position": 86,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ARC-AGI-2",
@@ -1053,7 +1065,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 86,
+        "position": 87,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-Gym",
@@ -1065,7 +1077,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 87,
+        "position": 88,
         "item": {
           "@type": "SoftwareApplication",
           "name": "swe-smith",
@@ -1077,7 +1089,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 88,
+        "position": 89,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_evals",
@@ -1089,7 +1101,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 89,
+        "position": 90,
         "item": {
           "@type": "SoftwareApplication",
           "name": "arc-agi-benchmarking",
@@ -1101,7 +1113,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 90,
+        "position": 91,
         "item": {
           "@type": "SoftwareApplication",
           "name": "VitaBench",
@@ -1113,7 +1125,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 91,
+        "position": 92,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgencyBench",
@@ -1125,7 +1137,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 92,
+        "position": 93,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta-evals",
@@ -1137,7 +1149,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 93,
+        "position": 94,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SUPER",
@@ -1149,7 +1161,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 94,
+        "position": 95,
         "item": {
           "@type": "SoftwareApplication",
           "name": "TRAIL",
@@ -1161,7 +1173,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 95,
+        "position": 96,
         "item": {
           "@type": "SoftwareApplication",
           "name": "gpt-researcher",
@@ -1173,7 +1185,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 96,
+        "position": 97,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openagents",
@@ -1185,7 +1197,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 97,
+        "position": 98,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Daytona",
@@ -1197,7 +1209,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 98,
+        "position": 99,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Mem0",
@@ -1209,7 +1221,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 99,
+        "position": 100,
         "item": {
           "@type": "SoftwareApplication",
           "name": "LiteLLM",
@@ -1221,7 +1233,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 100,
+        "position": 101,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Composio",
@@ -1233,7 +1245,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 101,
+        "position": 102,
         "item": {
           "@type": "SoftwareApplication",
           "name": "smolagents",
@@ -1245,7 +1257,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 102,
+        "position": 103,
         "item": {
           "@type": "SoftwareApplication",
           "name": "vercel/ai",
@@ -1257,7 +1269,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 103,
+        "position": 104,
         "item": {
           "@type": "SoftwareApplication",
           "name": "deepagents",
@@ -1269,7 +1281,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 104,
+        "position": 105,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pydantic-ai",
@@ -1281,7 +1293,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 105,
+        "position": 106,
         "item": {
           "@type": "SoftwareApplication",
           "name": "E2B",
@@ -1293,7 +1305,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 106,
+        "position": 107,
         "item": {
           "@type": "SoftwareApplication",
           "name": "strands-agents",
@@ -1305,7 +1317,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 107,
+        "position": 108,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Cloudflare Agents",
@@ -1317,7 +1329,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 108,
+        "position": 109,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-js",
@@ -1329,7 +1341,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 109,
+        "position": 110,
         "item": {
           "@type": "SoftwareApplication",
           "name": "open-harness",
@@ -1341,7 +1353,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 110,
+        "position": 111,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Community-curated agent lists",

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Best of Agent Harnesses
 
-> Hand-curated, ranked list of 110 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 10 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-06-26.
+> Hand-curated, ranked list of 111 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 10 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-06-26.
 
 Maintained at https://github.com/RyanAlberts/best-of-Agent-Harnesses (CC-BY-SA-4.0).
 Structured data: https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses/main/harnesses.json
@@ -74,7 +74,7 @@ Harnesses designed for unattended runs, batches, and fleets: opencode, OpenHands
 Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n, langgraph, mastra, letta, deepagents, pydantic-ai, Cloudflare Agents.
 
 ### How many of these agent harnesses are open source?
-96 of 110 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+97 of 111 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 The runtime that turns a model into an agent: it decides what the model's reasoning is allowed to touch, and supplies the orchestration, tool wiring, memory, error recovery, and guardrails around per-turn inference.
@@ -97,7 +97,7 @@ Formats, runtimes, and patterns that reveal context, tools, or instructions in l
 - [spring-ai-tool-search-tool](https://github.com/spring-ai-community/spring-ai-tool-search-tool) — ⭐75, mostly simple, autonomy: n/a, recovery: n/a, open-source: Dynamic tool discovery for Spring AI: model gets a search tool first, then pulls definitions for relevant tools; 34–64% token reduction across providers. [tool-discovery]
 - [ToolRAG](https://github.com/antl3x/ToolRAG) — ⭐28, mostly simple, autonomy: n/a, recovery: n/a, open-source: Semantic tool retrieval for LLMs; serves only the tools the user query demands (MCP-compatible), unlimited tool sets with zero context penalty. [mcp, tool-discovery]
 
-## Coding agent products (IDEs, CLIs, full suites) (11 projects)
+## Coding agent products (IDEs, CLIs, full suites) (12 projects)
 
 Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Dockerized workspaces. Each entry notes which part is the harness (the agent loop, tool wiring, approval model) versus the UI shell (VS Code extension, TUI, browser client).
 
@@ -110,6 +110,7 @@ Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Docker
 - [goose](https://github.com/aaif-goose/goose) — ⭐50.2k, slightly complex, autonomy: headless, recovery: resumable, open-source: Block-originated Rust agent, now stewarded by the Linux Foundation's Agentic AI Foundation (`aaif-goose/goose`). The **harness** is the MCP/ACP extension model with recipes and provider choice; there's no fixed UI slot—you bolt it into whatever shell you use. [mcp, rust]
 - [crush](https://github.com/charmbracelet/crush) — ⭐25.8k, slightly complex, autonomy: bounded, recovery: resumable, restricted (FSL-1.1-MIT): Charm's terminal coding agent (Charm's fork of the original OpenCode). The **harness** is the tool-calling loop with session persistence; the Bubble Tea TUI is the shell. [memory, cli, tui]
 - [Roo Code](https://github.com/RooCodeInc/Roo-Code) — ⭐24.3k, slightly complex, autonomy: step-gated, recovery: resumable, open-source: VS Code/Cursor extension in the Cline lineage. The **harness** is the approval-gated agent with custom modes and a strong MCP story; the IDE is the UI. Popular community fork when you want that workflow without the upstream extension. [mcp, workflow, ide, typescript]
+- [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐14.9k, slightly complex, autonomy: bounded, recovery: resumable, open-source: Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core. [browser, provider-agnostic, cli, ide, rust, python, typescript]
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐519, slightly complex, autonomy: checkpoint-gated, recovery: none, unknown: Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. [mcp, rust, python, typescript]
 - [coderClaw](https://github.com/SeanHogg/BuilderForceAgents) — ⭐3, slightly complex, autonomy: bounded, recovery: none, unknown: Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers. [ide, typescript]
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -112,6 +112,10 @@ projects:
     github_id: SeanHogg/BuilderForceAgents
     labels: ["javascript"]
     category: "coding-agent-products"
+  - name: oh-my-pi
+    github_id: can1357/oh-my-pi
+    labels: ["javascript"]
+    category: "coding-agent-products"
   - name: Open Interpreter
     github_id: openinterpreter/openinterpreter
     labels: ["python"]

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -193,6 +193,9 @@ PROJECTS: dict[str, list[Project]] = {
         Project("coderClaw", "SeanHogg/BuilderForceAgents",
                 "Self-hosted multi-role coding system (Creator, Reviewer, Test, Refactor, etc.) with AST and semantic maps; IDE-agnostic, chat-channel triggers.",
                 "slightly complex (multi-role, AST/semantic)", oss="❓", labels=["javascript"]),
+        Project("oh-my-pi", "can1357/oh-my-pi",
+                "Terminal coding agent (fork of Pi) that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core.",
+                "slightly complex (terminal agent, LSP/DAP, multi-provider)", labels=["javascript"]),
         Project("Open Interpreter", "openinterpreter/openinterpreter",
                 "Lightweight terminal coding agent oriented to open models (DeepSeek, Kimi, Qwen). The **harness** is a code-execution loop — the model writes code, the harness executes it with confirmation gates; the CLI is the shell. The original \"let the LLM run code on my machine\" project, reborn for open weights.",
                 "mostly simple (lean code-exec loop)", labels=["python"]),
@@ -524,6 +527,7 @@ META: dict[str, tuple[int, str, str]] = {
     "aaif-goose/goose": (50240, "https://block.github.io/goose/docs/guides/recipes/", "Goose recipes guide"),
     "HarnessLab/claw-code-agent": (519, "https://github.com/HarnessLab/claw-code-agent#-quick-start", "Quick Start guide"),
     "SeanHogg/BuilderForceAgents": (3, "https://github.com/SeanHogg/BuilderForceAgents#readme", "Multi-agent README"),
+    "can1357/oh-my-pi": (14939, "https://github.com/can1357/oh-my-pi/blob/main/docs/lsp-config.md", "LSP wired into edits"),
     # coding-harness-configs
     "gsd-build/get-shit-done": (64535, "https://github.com/gsd-build/get-shit-done/blob/main/commands/gsd/ship.md", "gsd:ship command"),
     "garrytan/gstack": (116407, "https://github.com/garrytan/gstack/blob/main/ship/SKILL.md", "/ship SKILL.md"),
@@ -681,6 +685,7 @@ AXES: "dict[str, tuple[str, str]]" = {
     "RooCodeInc/Roo-Code": ("step-gated", "resumable"),
     "HarnessLab/claw-code-agent": ("checkpoint-gated", "none"),
     "SeanHogg/BuilderForceAgents": ("bounded", "none"),
+    "can1357/oh-my-pi": ("bounded", "resumable"),
     # coding-harness-configs
     "obra/superpowers": ("n/a", "n/a"),
     "affaan-m/ECC": ("n/a", "n/a"),


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Add a project

## Description

Adds **oh-my-pi** ([can1357/oh-my-pi](https://github.com/can1357/oh-my-pi), `omp`) to the **Coding agent products (IDEs, CLIs, full suites)** category.

`omp` is a terminal coding agent — a fork of [Pi](https://github.com/badlogic/pi-mono) — that wires the IDE into the harness: hash-anchored edits, a 32-tool loop tuned per-model, LSP (rename/references/diagnostics) on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's own tools, browser control, and 40+ provider support (Claude/OpenAI/Gemini/local). ~55k lines of Rust core, MIT-licensed.

**Source of truth:** edited `scripts/generate.py` (`PROJECTS` + `META` + `AXES`), then ran `python scripts/generate.py` to regenerate `projects.yaml`, `README.md`, `harnesses.json`, `harnesses.jsonld`, `llms.txt`, `TAGS.md`, `feed.json`, `config/header.md`, and the SVG assets. The diff is exactly one new project — no star drift, no reformatting of existing rows (jsonld churn is position renumbering + `numberOfItems` 110→111).

Scoring (editorial, from public docs — corrections welcome):
- axis: `slightly complex (terminal agent, LSP/DAP, multi-provider)`
- autonomy: `bounded` (interactive terminal agent, approval modes)
- recovery: `resumable` (sessions resume)
- oss: `✅` (MIT)
- labels: `["javascript"]` (TypeScript/Bun; matches the list's convention for opencode/Gemini CLI/Cline)
- tags auto-derived: `browser` · `provider-agnostic` · `cli` · `ide` · `rust` · `python` · `typescript`

Verified repo metadata: public, MIT, ~15k stars, TypeScript; npm `@oh-my-pi/pi-coding-agent` (v16.2.2).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not hand-edited the `README.md` file. `projects.yaml` and all derived artifacts are regenerated from `scripts/generate.py` (the canonical source), which is the only hand-edited file in this PR.