### PR TITLE
Add AgentBox to projects.yaml (coding-agent-products)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -72,6 +72,10 @@ projects:
     github_id: antl3x/ToolRAG
     category: "progressive-disclosure"
   # Coding agent products (IDEs, CLIs, full suites)
+  - name: AgentBox
+    github_id: madarco/agentbox
+    labels: ["javascript"]
+    category: "coding-agent-products"
   - name: Cline
     github_id: cline/cline
     labels: ["javascript"]


### PR DESCRIPTION
Adds [AgentBox](https://github.com/madarco/agentbox) to `projects.yaml` under **coding-agent-products** (editing the source of truth so the ranked README regenerates, per the contribution note).

AgentBox is a turnkey coding-agent product: `npm -g install @madarco/agentbox`, then `agentbox claude` teleports your project into its own sandboxed VM (local Docker, self-hosted, or cloud: Hetzner / Daytona / Vercel / E2B / DigitalOcean) and launches the agent. The harness part is per-agent VM isolation + sub-1s checkpoint startup + host-kept git credentials; it runs Claude Code, Codex, and OpenCode. MIT.