### PR TITLE
Add Proliferate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <a href="https://best-of.org" title="Best-of Badge"><img src="http://bit.ly/3o3EHNN"></a>
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-111-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-112-blue.svg?color=5ac4bf"></a>
     <a href="https://ryanalberts.github.io/best-of-Agent-Harnesses/" title="Browse the searchable site"><img src="https://img.shields.io/badge/website-live-5ac4bf.svg"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
@@ -97,7 +97,7 @@ claude mcp add agent-harnesses -- uvx agent-harnesses-mcp
 - [For agents: harnesses.json, llms.txt, MCP server](#for-agents)
 - [FAQ](#faq)
 - [Progressive disclosure harnesses](#progressive-disclosure-harnesses) _6 projects_
-- [Coding agent products (IDEs, CLIs, full suites)](#coding-agent-products-ides-clis-full-suites) _11 projects_
+- [Coding agent products (IDEs, CLIs, full suites)](#coding-agent-products-ides-clis-full-suites) _12 projects_
 - [Coding harness configs and SDKs](#coding-harness-configs-and-sdks) _10 projects_
 - [Personal agent runtimes](#personal-agent-runtimes) _8 projects_
 - [Frameworks](#frameworks) _23 projects_
@@ -155,6 +155,7 @@ _Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Docke
 | 9 | <a name="oh-my-pi"></a>[**oh-my-pi**](https://github.com/can1357/oh-my-pi) | [17k](https://github.com/can1357/oh-my-pi/stargazers) | Terminal coding agent (fork of Pi) that wires the IDE into the **harness**: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ providers (Claude/OpenAI/Gemini/local). ~55k-line Rust core. <sup>`browser` · `provider-agnostic` · `cli` · `ide` · `rust`</sup> | ✅ | slightly complex (terminal agent, LSP/DAP, multi-provider) | [LSP wired into edits](https://github.com/can1357/oh-my-pi/blob/main/docs/lsp-config.md) |
 | 10 | <a name="claw-code-agent"></a>[**claw-code-agent**](https://github.com/HarnessLab/claw-code-agent) | [526](https://github.com/HarnessLab/claw-code-agent/stargazers) | Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. <sup>`mcp` · `rust` · `python` · `typescript`</sup> | ❓ | slightly complex (pure Python, plugin runtime) | [Quick Start guide](https://github.com/HarnessLab/claw-code-agent#-quick-start) |
 | 11 | <a name="agentbox"></a>[**AgentBox**](https://github.com/madarco/agentbox) | [238](https://github.com/madarco/agentbox/stargazers) | Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop. <sup>`sandbox` · `typescript`</sup> | ✅ | slightly complex (VM-per-agent sandbox, parallel fan-out) | [Parallel agents quick start](https://github.com/madarco/agentbox#readme) |
+| 12 | <a name="proliferate"></a>[**Proliferate**](https://github.com/proliferate-ai/proliferate) | [149](https://github.com/proliferate-ai/proliferate/stargazers) | Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context. <sup>`multi-agent` · `sandbox` · `ide` · `typescript`</sup> | ✅ | complex (multi-agent workspace orchestration — product suite) | [Product README](https://github.com/proliferate-ai/proliferate#readme) |
 
 ## Coding harness configs and SDKs
 
@@ -366,7 +367,7 @@ Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n
 
 ### How many of these agent harnesses are open source?
 
-97 of 111 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+98 of 112 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable -->
 # Tags — cross-reference
 
-_Auto-generated from `scripts/generate.py`. 111 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
+_Auto-generated from `scripts/generate.py`. 112 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
 
 Tag chips appear next to each project in [README.md](README.md). This page lists every tag once with the projects that carry it, grouped by category and sorted by GitHub stars within each category.
 
 ## All tags
 
-[`mcp`](#mcp) (22) · [`memory`](#memory) (20) · [`multi-agent`](#multi-agent) (19) · [`evals`](#evals) (14) · [`voice`](#voice) (2) · [`vision`](#vision) (2) · [`browser`](#browser) (5) · [`sandbox`](#sandbox) (19) · [`low-code`](#low-code) (4) · [`rag`](#rag) (4) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (4) · [`workflow`](#workflow) (6) · [`typed`](#typed) (3) · [`local`](#local) (1) · [`provider-agnostic`](#provider-agnostic) (9) · [`cli`](#cli) (11) · [`ide`](#ide) (5) · [`tui`](#tui) (2) · [`rust`](#rust) (3) · [`python`](#python) (62) · [`typescript`](#typescript) (29)
+[`mcp`](#mcp) (22) · [`memory`](#memory) (20) · [`multi-agent`](#multi-agent) (20) · [`evals`](#evals) (14) · [`voice`](#voice) (2) · [`vision`](#vision) (2) · [`browser`](#browser) (5) · [`sandbox`](#sandbox) (20) · [`low-code`](#low-code) (4) · [`rag`](#rag) (4) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (4) · [`workflow`](#workflow) (6) · [`typed`](#typed) (3) · [`local`](#local) (1) · [`provider-agnostic`](#provider-agnostic) (9) · [`cli`](#cli) (11) · [`ide`](#ide) (6) · [`tui`](#tui) (2) · [`rust`](#rust) (3) · [`python`](#python) (62) · [`typescript`](#typescript) (30)
 
 ---
 
@@ -107,6 +107,10 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 ---
 
 ## `multi-agent`
+
+**Coding agent products (IDEs, CLIs, full suites)**
+
+- [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐149 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 
 **Coding harness configs and SDKs**
 
@@ -226,6 +230,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Codex](https://github.com/openai/codex) — ⭐96.6k — OpenAI's terminal coding agent. The **harness** is the sandboxed tool-call loop with multi-provider support; the CLI is the shell. Reference implementation for "official CLI that ships code."
 - [OpenHands](https://github.com/OpenHands/OpenHands) — ⭐80.2k — Dockerized software-engineering agent. The **harness** is the bash/editor/browser toolset with micro-agents and event-stream session bridging; Docker is the sandbox. Main OSS choice for teams self-hosting autonomous repo work.
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐238 — Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop.
+- [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐149 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 
 **Personal agent runtimes**
 
@@ -422,6 +427,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 
 - [Cline](https://github.com/cline/cline) — ⭐64.5k — VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.
 - [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐17k — Terminal coding agent (fork of Pi) that wires the IDE into the **harness**: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ providers (Claude/OpenAI/Gemini/local). ~55k-line Rust core.
+- [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐149 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 
 **Coding harness configs and SDKs**
 
@@ -561,6 +567,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Cline](https://github.com/cline/cline) — ⭐64.5k — VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐526 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐238 — Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop.
+- [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐149 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 
 **Coding harness configs and SDKs**
 
@@ -714,6 +721,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Cline](https://github.com/cline/cline) — ⭐64.5k — VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐526 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐238 — Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop.
+- [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐149 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 
 **Coding harness configs and SDKs**
 

--- a/assets/axes-grid.svg
+++ b/assets/axes-grid.svg
@@ -25,7 +25,7 @@
 <text x="44" y="395" font-size="13" fill="#6b7280" transform="rotate(-90 44 395)" text-anchor="middle">recovery: crash = start over&#160;&#160;→&#160;&#160;survives restarts</text>
 <text x="832.5" y="652.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">8</text>
 <text x="832.5" y="254.5" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">4</text>
-<text x="832.5" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">16</text>
+<text x="832.5" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">17</text>
 <text x="397.5" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">1</text>
 <text x="1050.0" y="387.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">21</text>
 <text x="615.0" y="652.0" text-anchor="end" font-size="12" fill="#d1d5db" font-weight="700">1</text>
@@ -39,6 +39,7 @@
 <circle cx="931.8" cy="340.8" r="5.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Talon — ⭐61</title></circle>
 <circle cx="916.2" cy="566.6" r="5.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>letta-evals — ⭐77</title></circle>
 <circle cx="897.7" cy="600.4" r="5.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>AgencyBench — ⭐88</title></circle>
+<circle cx="781.6" cy="354.0" r="5.5" fill="#ef4444" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Proliferate — ⭐149</title></circle>
 <circle cx="1009.9" cy="615.1" r="5.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>VitaBench — ⭐154</title></circle>
 <circle cx="930.4" cy="442.8" r="5.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>agent-qa — ⭐156</title></circle>
 <circle cx="725.8" cy="564.1" r="5.5" fill="#3b82f6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>SuperAgentX — ⭐200</title></circle>
@@ -127,5 +128,5 @@
 <text x="993.7" y="164.6" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">n8n</text>
 <text x="1004.2" y="448.5" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">langflow</text>
 <text x="534.2" y="313.2" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">aider</text>
-<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">82 loop-owning projects shown · 29 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
+<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">83 loop-owning projects shown · 29 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
 </svg>

--- a/assets/landscape.svg
+++ b/assets/landscape.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 880" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
 <rect width="1320" height="880" fill="#ffffff" rx="8"/>
 <text x="660.0" y="52" text-anchor="middle" font-size="30" font-weight="700" fill="#111827">The Agent Harness Landscape</text>
-<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">111 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-07-09</text>
+<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">112 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-07-09</text>
 <circle cx="80" cy="106" r="6" fill="#8b5cf6"/>
 <text x="91" y="110" font-size="12.5" fill="#374151">Progressive disclosure</text>
 <circle cx="262.2" cy="106" r="6" fill="#ef4444"/>
@@ -43,7 +43,7 @@
 <text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">45 projects</text>
 <line x1="987.5" y1="168" x2="987.5" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="1138.8" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">complex</text>
-<text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">39 projects</text>
+<text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">40 projects</text>
 <line x1="80" y1="750" x2="1290" y2="750" stroke="#d1d5db" stroke-width="1.5"/>
 <text x="685.0" y="830" text-anchor="middle" font-size="13" fill="#6b7280">←  less to adopt: a file format, one concept&#160;&#160;·&#160;&#160;simplicity ↔ capability&#160;&#160;·&#160;&#160;full platforms with their own runtime: more to adopt  →</text>
 <circle cx="316.4" cy="749.9" r="4.5" fill="#10b981" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>agentlog — ⭐0</title></circle>
@@ -58,6 +58,7 @@
 <circle cx="811.5" cy="580.5" r="4.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Talon — ⭐61</title></circle>
 <circle cx="489.2" cy="569.0" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>letta-evals — ⭐77</title></circle>
 <circle cx="1070.6" cy="562.3" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>AgencyBench — ⭐88</title></circle>
+<circle cx="1199.5" cy="536.2" r="4.5" fill="#ef4444" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Proliferate — ⭐149</title></circle>
 <circle cx="1213.3" cy="534.6" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>VitaBench — ⭐154</title></circle>
 <circle cx="809.7" cy="534.0" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>agent-qa — ⭐156</title></circle>
 <circle cx="1139.9" cy="526.3" r="4.5" fill="#8b5cf6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>ToolGen — ⭐182</title></circle>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -5,6 +5,6 @@
   <text x="140" y="184" font-family="Helvetica,Arial,sans-serif" font-size="32" fill="#5ac4bf" font-weight="700">best-of-Agent-Harnesses</text>
   <text x="80" y="300" font-family="Helvetica,Arial,sans-serif" font-size="74" fill="#f0f6fc" font-weight="800">Best of Agent Harnesses</text>
   <text x="80" y="378" font-family="Helvetica,Arial,sans-serif" font-size="38" fill="#9ca3af">The runtimes that close the loop between a model and the world.</text>
-  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">111 harnesses · 10 categories · MCP-ready · weekly-rescored</text>
+  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">112 harnesses · 10 categories · MCP-ready · weekly-rescored</text>
   <text x="80" y="566" font-family="Helvetica,Arial,sans-serif" font-size="27" fill="#9ca3af">github.com/RyanAlberts/best-of-Agent-Harnesses</text>
 </svg>

--- a/config/header.md
+++ b/config/header.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <a href="https://best-of.org" title="Best-of Badge"><img src="http://bit.ly/3o3EHNN"></a>
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-111-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-112-blue.svg?color=5ac4bf"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
 </p>

--- a/feed.json
+++ b/feed.json
@@ -16,7 +16,7 @@
       "title": "Agent Harnesses list refreshed — 2026-07-09",
       "url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses",
       "date_published": "2026-07-09T00:00:00Z",
-      "content_text": "111 harnesses across 10 categories. Stars captured 2026-07-09. Most-starred: awesome-cursorrules, agents.md, langgraph-bigtool, MCP-Zero, ToolGen."
+      "content_text": "112 harnesses across 10 categories. Stars captured 2026-07-09. Most-starred: awesome-cursorrules, agents.md, langgraph-bigtool, MCP-Zero, ToolGen."
     },
     {
       "id": "refresh-2026-07-05",

--- a/harnesses.json
+++ b/harnesses.json
@@ -9,7 +9,7 @@
     "feed_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/feed.json",
     "license": "CC-BY-SA-4.0",
     "stars_captured": "2026-07-09",
-    "project_count": 111,
+    "project_count": 112,
     "graveyard_count": 4,
     "tiers": [
       "super simple",
@@ -335,7 +335,7 @@
     {
       "kind": "derived",
       "q": "How many of these agent harnesses are open source?",
-      "a": "97 of 111 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
+      "a": "98 of 112 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
       "slug": "how-many-of-these-agent-harnesses-are-open-source"
     },
     {
@@ -880,6 +880,36 @@
       "example": {
         "label": "Parallel agents quick start",
         "url": "https://github.com/madarco/agentbox#readme"
+      }
+    },
+    {
+      "name": "Proliferate",
+      "github_id": "proliferate-ai/proliferate",
+      "url": "https://github.com/proliferate-ai/proliferate",
+      "slug": "proliferate",
+      "anchor_url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses#proliferate",
+      "page_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/h/proliferate/",
+      "description": "Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.",
+      "category": "coding-agent-products",
+      "category_title": "Coding agent products (IDEs, CLIs, full suites)",
+      "stars": 149,
+      "tier": "complex",
+      "tier_rank": 4,
+      "axis": "complex (multi-agent workspace orchestration — product suite)",
+      "autonomy": "bounded",
+      "autonomy_rank": 3,
+      "recovery": "resumable",
+      "recovery_rank": 3,
+      "license_signal": "open-source",
+      "tags": [
+        "multi-agent",
+        "sandbox",
+        "ide",
+        "typescript"
+      ],
+      "example": {
+        "label": "Product README",
+        "url": "https://github.com/proliferate-ai/proliferate#readme"
       }
     },
     {

--- a/harnesses.jsonld
+++ b/harnesses.jsonld
@@ -29,7 +29,7 @@
   ],
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": 111,
+    "numberOfItems": 112,
     "itemListElement": [
       {
         "@type": "ListItem",
@@ -240,6 +240,18 @@
         "position": 18,
         "item": {
           "@type": "SoftwareApplication",
+          "name": "Proliferate",
+          "url": "https://github.com/proliferate-ai/proliferate",
+          "description": "Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.",
+          "applicationCategory": "DeveloperApplication",
+          "keywords": "multi-agent, sandbox, ide, typescript"
+        }
+      },
+      {
+        "@type": "ListItem",
+        "position": 19,
+        "item": {
+          "@type": "SoftwareApplication",
           "name": "superpowers",
           "url": "https://github.com/obra/superpowers",
           "description": "Performance-oriented harness pack for Claude Code, Codex, OpenCode, Cursor: skills, instincts, memory, security, research-first workflows. Treats harness engineering itself as the performance lever.",
@@ -249,7 +261,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 19,
+        "position": 20,
         "item": {
           "@type": "SoftwareApplication",
           "name": "everything-claude-code",
@@ -261,7 +273,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 20,
+        "position": 21,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Anthropic Skills",
@@ -273,7 +285,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 21,
+        "position": 22,
         "item": {
           "@type": "SoftwareApplication",
           "name": "GStack",
@@ -285,7 +297,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 22,
+        "position": 23,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-agent",
@@ -297,7 +309,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 23,
+        "position": 24,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Claude Agent SDK",
@@ -309,7 +321,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 24,
+        "position": 25,
         "item": {
           "@type": "SoftwareApplication",
           "name": "RepoMaster",
@@ -321,7 +333,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 25,
+        "position": 26,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoHarness",
@@ -333,7 +345,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 26,
+        "position": 27,
         "item": {
           "@type": "SoftwareApplication",
           "name": "LoopTroop",
@@ -345,7 +357,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 27,
+        "position": 28,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pmstack",
@@ -357,7 +369,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 28,
+        "position": 29,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenClaw",
@@ -369,7 +381,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 29,
+        "position": 30,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Hermes",
@@ -381,7 +393,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 30,
+        "position": 31,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Khoj",
@@ -393,7 +405,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 31,
+        "position": 32,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Eliza",
@@ -405,7 +417,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 32,
+        "position": 33,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Zero",
@@ -417,7 +429,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 33,
+        "position": 34,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenHarness (HKUDS)",
@@ -429,7 +441,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 34,
+        "position": 35,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AIlice",
@@ -441,7 +453,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 35,
+        "position": 36,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Talon",
@@ -453,7 +465,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 36,
+        "position": 37,
         "item": {
           "@type": "SoftwareApplication",
           "name": "n8n",
@@ -465,7 +477,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 37,
+        "position": 38,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoGPT",
@@ -477,7 +489,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 38,
+        "position": 39,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langflow",
@@ -489,7 +501,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 39,
+        "position": 40,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Dify",
@@ -501,7 +513,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 40,
+        "position": 41,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langchain",
@@ -513,7 +525,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 41,
+        "position": 42,
         "item": {
           "@type": "SoftwareApplication",
           "name": "browser-use",
@@ -525,7 +537,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 42,
+        "position": 43,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Flowise",
@@ -537,7 +549,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 43,
+        "position": 44,
         "item": {
           "@type": "SoftwareApplication",
           "name": "llama-index",
@@ -549,7 +561,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 44,
+        "position": 45,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agno",
@@ -561,7 +573,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 45,
+        "position": 46,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langgraph",
@@ -573,7 +585,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 46,
+        "position": 47,
         "item": {
           "@type": "SoftwareApplication",
           "name": "semantic-kernel",
@@ -585,7 +597,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 47,
+        "position": 48,
         "item": {
           "@type": "SoftwareApplication",
           "name": "mastra",
@@ -597,7 +609,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 48,
+        "position": 49,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta",
@@ -609,7 +621,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 49,
+        "position": 50,
         "item": {
           "@type": "SoftwareApplication",
           "name": "rasa",
@@ -621,7 +633,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 50,
+        "position": 51,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Google ADK",
@@ -633,7 +645,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 51,
+        "position": 52,
         "item": {
           "@type": "SoftwareApplication",
           "name": "botpress",
@@ -645,7 +657,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 52,
+        "position": 53,
         "item": {
           "@type": "SoftwareApplication",
           "name": "R2R",
@@ -657,7 +669,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 53,
+        "position": 54,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-squad",
@@ -669,7 +681,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 54,
+        "position": 55,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentVerse",
@@ -681,7 +693,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 55,
+        "position": 56,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Bee Agent Framework",
@@ -693,7 +705,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 56,
+        "position": 57,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentStack",
@@ -705,7 +717,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 57,
+        "position": 58,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentSilex",
@@ -717,7 +729,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 58,
+        "position": 59,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SuperAgentX",
@@ -729,7 +741,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 59,
+        "position": 60,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MetaGPT",
@@ -741,7 +753,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 60,
+        "position": 61,
         "item": {
           "@type": "SoftwareApplication",
           "name": "autogen",
@@ -753,7 +765,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 61,
+        "position": 62,
         "item": {
           "@type": "SoftwareApplication",
           "name": "crewAI",
@@ -765,7 +777,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 62,
+        "position": 63,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ChatDev",
@@ -777,7 +789,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 63,
+        "position": 64,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-python",
@@ -789,7 +801,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 64,
+        "position": 65,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Microsoft Agent Framework",
@@ -801,7 +813,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 65,
+        "position": 66,
         "item": {
           "@type": "SoftwareApplication",
           "name": "PraisonAI",
@@ -813,7 +825,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 66,
+        "position": 67,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentRL",
@@ -825,7 +837,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 67,
+        "position": 68,
         "item": {
           "@type": "SoftwareApplication",
           "name": "claude-mem",
@@ -837,7 +849,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 68,
+        "position": 69,
         "item": {
           "@type": "SoftwareApplication",
           "name": "aider",
@@ -849,7 +861,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 69,
+        "position": 70,
         "item": {
           "@type": "SoftwareApplication",
           "name": "continue",
@@ -861,7 +873,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 70,
+        "position": 71,
         "item": {
           "@type": "SoftwareApplication",
           "name": "github-mcp-server",
@@ -873,7 +885,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 71,
+        "position": 72,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Python SDK",
@@ -885,7 +897,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 72,
+        "position": 73,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP TypeScript SDK",
@@ -897,7 +909,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 73,
+        "position": 74,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Inspector",
@@ -909,7 +921,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 74,
+        "position": 75,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Registry",
@@ -921,7 +933,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 75,
+        "position": 76,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Docker MCP Gateway",
@@ -933,7 +945,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 76,
+        "position": 77,
         "item": {
           "@type": "SoftwareApplication",
           "name": "puppeteer-real-browser-mcp",
@@ -945,7 +957,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 77,
+        "position": 78,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Better-OpenCodeMCP",
@@ -957,7 +969,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 78,
+        "position": 79,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agentlog",
@@ -969,7 +981,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 79,
+        "position": 80,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Lightning",
@@ -981,7 +993,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 80,
+        "position": 81,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-bench",
@@ -993,7 +1005,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 81,
+        "position": 82,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentBench",
@@ -1005,7 +1017,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 82,
+        "position": 83,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_ai",
@@ -1017,7 +1029,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 83,
+        "position": 84,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebArena",
@@ -1029,7 +1041,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 84,
+        "position": 85,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebVoyager",
@@ -1041,7 +1053,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 85,
+        "position": 86,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ARC-AGI-2",
@@ -1053,7 +1065,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 86,
+        "position": 87,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-Gym",
@@ -1065,7 +1077,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 87,
+        "position": 88,
         "item": {
           "@type": "SoftwareApplication",
           "name": "swe-smith",
@@ -1077,7 +1089,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 88,
+        "position": 89,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_evals",
@@ -1089,7 +1101,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 89,
+        "position": 90,
         "item": {
           "@type": "SoftwareApplication",
           "name": "arc-agi-benchmarking",
@@ -1101,7 +1113,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 90,
+        "position": 91,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-qa",
@@ -1113,7 +1125,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 91,
+        "position": 92,
         "item": {
           "@type": "SoftwareApplication",
           "name": "VitaBench",
@@ -1125,7 +1137,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 92,
+        "position": 93,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgencyBench",
@@ -1137,7 +1149,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 93,
+        "position": 94,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta-evals",
@@ -1149,7 +1161,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 94,
+        "position": 95,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SUPER",
@@ -1161,7 +1173,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 95,
+        "position": 96,
         "item": {
           "@type": "SoftwareApplication",
           "name": "TRAIL",
@@ -1173,7 +1185,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 96,
+        "position": 97,
         "item": {
           "@type": "SoftwareApplication",
           "name": "gpt-researcher",
@@ -1185,7 +1197,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 97,
+        "position": 98,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openagents",
@@ -1197,7 +1209,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 98,
+        "position": 99,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Daytona",
@@ -1209,7 +1221,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 99,
+        "position": 100,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Mem0",
@@ -1221,7 +1233,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 100,
+        "position": 101,
         "item": {
           "@type": "SoftwareApplication",
           "name": "LiteLLM",
@@ -1233,7 +1245,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 101,
+        "position": 102,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Composio",
@@ -1245,7 +1257,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 102,
+        "position": 103,
         "item": {
           "@type": "SoftwareApplication",
           "name": "smolagents",
@@ -1257,7 +1269,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 103,
+        "position": 104,
         "item": {
           "@type": "SoftwareApplication",
           "name": "deepagents",
@@ -1269,7 +1281,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 104,
+        "position": 105,
         "item": {
           "@type": "SoftwareApplication",
           "name": "vercel/ai",
@@ -1281,7 +1293,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 105,
+        "position": 106,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pydantic-ai",
@@ -1293,7 +1305,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 106,
+        "position": 107,
         "item": {
           "@type": "SoftwareApplication",
           "name": "E2B",
@@ -1305,7 +1317,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 107,
+        "position": 108,
         "item": {
           "@type": "SoftwareApplication",
           "name": "strands-agents",
@@ -1317,7 +1329,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 108,
+        "position": 109,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Cloudflare Agents",
@@ -1329,7 +1341,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 109,
+        "position": 110,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-js",
@@ -1341,7 +1353,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 110,
+        "position": 111,
         "item": {
           "@type": "SoftwareApplication",
           "name": "open-harness",
@@ -1353,7 +1365,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 111,
+        "position": 112,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Community-curated agent lists",

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Best of Agent Harnesses
 
-> Hand-curated, ranked list of 111 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 10 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-07-09.
+> Hand-curated, ranked list of 112 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 10 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-07-09.
 
 Maintained at https://github.com/RyanAlberts/best-of-Agent-Harnesses (CC-BY-SA-4.0).
 Structured data: https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses/main/harnesses.json
@@ -74,7 +74,7 @@ Harnesses designed for unattended runs, batches, and fleets: opencode, OpenHands
 Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n, langgraph, mastra, letta, deepagents, pydantic-ai, Cloudflare Agents.
 
 ### How many of these agent harnesses are open source?
-97 of 111 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+98 of 112 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 The runtime that turns a model into an agent: it decides what the model's reasoning is allowed to touch, and supplies the orchestration, tool wiring, memory, error recovery, and guardrails around per-turn inference.
@@ -96,7 +96,7 @@ Formats, runtimes, and patterns that reveal context, tools, or instructions in l
 - [ToolGen](https://github.com/Reason-Wang/ToolGen) — ⭐182, complex, autonomy: n/a, recovery: n/a, unknown: ICLR 2025: unified tool retrieval and calling via generation; 47k+ tools without context stuffing—retrieval and invocation in one generative step. [tool-discovery, python]
 - [ToolRAG](https://github.com/antl3x/ToolRAG) — ⭐29, mostly simple, autonomy: n/a, recovery: n/a, open-source: Semantic tool retrieval for LLMs; serves only the tools the user query demands (MCP-compatible), unlimited tool sets with zero context penalty. [mcp, tool-discovery]
 
-## Coding agent products (IDEs, CLIs, full suites) (11 projects)
+## Coding agent products (IDEs, CLIs, full suites) (12 projects)
 
 Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Dockerized workspaces. Each entry notes which part is the harness (the agent loop, tool wiring, approval model) versus the UI shell (VS Code extension, TUI, browser client).
 
@@ -111,6 +111,7 @@ Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Docker
 - [oh-my-pi](https://github.com/can1357/oh-my-pi) — ⭐17k, slightly complex, autonomy: bounded, recovery: resumable, open-source: Terminal coding agent (fork of Pi) that wires the IDE into the **harness**: hash-anchored edits, a 32-tool loop tuned per-model, LSP rename/references/diagnostics on every write, a real DAP debugger (lldb/dlv/debugpy), long-lived Python + Bun execution kernels that call back into the agent's tools, browser control, and 40+ providers (Claude/OpenAI/Gemini/local). ~55k-line Rust core. [browser, provider-agnostic, cli, ide, rust, python]
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐526, slightly complex, autonomy: checkpoint-gated, recovery: none, unknown: Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. [mcp, rust, python, typescript]
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐238, slightly complex, autonomy: n/a, recovery: n/a, open-source: Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop. [sandbox, typescript]
+- [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐149, complex, autonomy: bounded, recovery: resumable, open-source: Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context. [multi-agent, sandbox, ide, typescript]
 
 ## Coding harness configs and SDKs (10 projects)
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -80,6 +80,10 @@ projects:
     github_id: madarco/agentbox
     labels: ["javascript"]
     category: "coding-agent-products"
+  - name: Proliferate
+    github_id: proliferate-ai/proliferate
+    labels: ["javascript"]
+    category: "coding-agent-products"
   - name: Cline
     github_id: cline/cline
     labels: ["javascript"]

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -170,6 +170,9 @@ PROJECTS: dict[str, list[Project]] = {
         Project("AgentBox", "madarco/agentbox",
                 "Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop.",
                 "slightly complex (VM-per-agent sandbox, parallel fan-out)", labels=["javascript"]),
+        Project("Proliferate", "proliferate-ai/proliferate",
+                "Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.",
+                "complex (multi-agent workspace orchestration — product suite)", labels=["javascript"]),
         Project("Cline", "cline/cline",
                 "VS Code extension whose **harness** is a plan-then-act loop with per-step human approval and cost transparency; the VS Code integration is the UI shell. Open-source counterweight to Cursor.",
                 "slightly complex (plan-then-act, approval gates)", labels=["javascript"]),
@@ -527,6 +530,7 @@ META: dict[str, tuple[int, str, str]] = {
     # coding-agent-products
     "can1357/oh-my-pi": (16958, "https://github.com/can1357/oh-my-pi/blob/main/docs/lsp-config.md", "LSP wired into edits"),
     "madarco/agentbox": (238, "https://github.com/madarco/agentbox#readme", "Parallel agents quick start"),
+    "proliferate-ai/proliferate": (149, "https://github.com/proliferate-ai/proliferate#readme", "Product README"),
     "cline/cline": (64486, "https://docs.cline.bot/features/plan-and-act", "Plan & Act mode"),
     "RooCodeInc/Roo-Code": (24310, "https://docs.roocode.com/features/custom-modes", "Custom modes guide"),
     "openai/codex": (96576, "https://developers.openai.com/codex/concepts/sandboxing", "Sandboxing concept"),
@@ -774,6 +778,7 @@ AXES: "dict[str, tuple[str, str]]" = {
     # coding-agent-products
     "can1357/oh-my-pi": ("bounded", "resumable"),
     "madarco/agentbox": ("n/a", "n/a"),
+    "proliferate-ai/proliferate": ("bounded", "resumable"),
     "anomalyco/opencode": ("headless", "resumable"),
     "google-gemini/gemini-cli": ("bounded", "resumable"),
     "openai/codex": ("bounded", "resumable"),


### PR DESCRIPTION
## Summary
- add Proliferate to coding agent products
- regenerate README, machine-readable data, tags, and assets

## Validation
- `python3 scripts/generate.py`
- `uvx --with markdown pytest tests/ -q`
