### PR TITLE
Pin mcp<2 to retain pre-2.0 fastmcp import path

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Ryan Alberts" }]
 keywords = ["mcp", "model-context-protocol", "agents", "agent-harness", "llm"]
-dependencies = ["mcp>=1.2"]
+dependencies = ["mcp>=1.2,<2"]
 
 [project.scripts]
 agent-harnesses-mcp = "agent_harnesses_mcp:main"


### PR DESCRIPTION
The Python MCP SDK 2.0.0 removed `mcp.server.fastmcp`. `agent_harnesses_mcp/__init__.py` imports `from mcp.server.fastmcp import FastMCP`, so installing against latest `mcp` makes the server crash on startup (`ModuleNotFoundError`).

Pin `mcp<2` so consumers always get a compatible SDK.

Reported 2026-07-30.