### PR TITLE
Weekly rescore 2026-08-16 — unblock the rescore workflow (traffic snapshot 403)

### DIFF
--- a/.github/workflows/weekly-rescore.yml
+++ b/.github/workflows/weekly-rescore.yml
@@ -48,7 +48,17 @@ jobs:
           # traffic snapshot: GitHub only retains 14 days of traffic data, so
           # this appends a weekly record to traffic-history.jsonl for real
           # trend analysis over time.
-          python3 scripts/snapshot_traffic.py | tee -a /tmp/refresh.log
+          #
+          # NON-FATAL on purpose. The traffic API needs admin-level access, which
+          # the secrets.GITHUB_TOKEN fallback does not have — it 403s and, under
+          # `set -euo pipefail`, took the whole 2026-08-16 rescore down with it
+          # (152 refreshed star counts thrown away because an optional telemetry
+          # step failed). A missing week of traffic history is a nuisance; a
+          # missing weekly rescore is the point of this workflow. The 403 still
+          # lands in the log and the run summary so it stays visible.
+          python3 scripts/snapshot_traffic.py 2>&1 | tee -a /tmp/refresh.log \
+            || echo "WARNING: traffic snapshot skipped (see error above) — rescore continues" \
+               | tee -a /tmp/refresh.log
           # discover runs BEFORE generate so the README/site radar section
           # hydrates from this week's queue, not last week's.
           python3 scripts/discover_candidates.py


### PR DESCRIPTION
**What kind of change is this?**

- [ ] Add a project → fill in the intake below
- [ ] Correct a project I maintain (description / example link / tier / axes score)
- [x] Scripts, site, docs, or CI
- [ ] Other:

**Description:**

**This is not the weekly rescore commit — it is the fix that makes the next one possible.** The 2026-08-16 rescore did not land, and without this change no future one would either.

[Run 31952458920](https://github.com/RyanAlberts/best-of-Agent-Harnesses/actions/runs/31952458920) failed with nothing committed. `refresh_stars.py` itself succeeded, but the following step, `scripts/snapshot_traffic.py`, returned `HTTP Error 403: Forbidden` on `/traffic/views`. Because the step runs under `set -euo pipefail`, that 403 aborted everything after it — `discover_candidates.py` and `generate.py` never ran, and 152 refreshed star counts were discarded.

Today was that step's **first scheduled run**: it landed 2026-08-12 (91f0bb9), after the last green run on 2026-08-09, so the failure path had never been exercised. GitHub's traffic API requires admin-level access, which the `secrets.GITHUB_TOKEN` fallback does not carry — so this would have failed identically every Sunday from here on.

This PR makes the traffic snapshot non-fatal. A missed week of traffic history is a nuisance; a missed weekly rescore defeats the workflow's purpose. The 403 still prints into `/tmp/refresh.log` and the run summary, so the underlying token problem stays visible instead of being silently swallowed.

**Action still needed from a maintainer:** set (or renew) the `RESCORE_PAT` secret with a token carrying admin/`repo` scope on this repository, or `traffic-history.jsonl` will stop accumulating even though the rescore now completes.

---

### Capture date and star changes

`2026-08-16`. **152 of 164 repos changed** — computed successfully by `refresh_stars.py` on the runner, but **not committed**, because the run died two steps later. `harnesses.json` still reads `stars_captured: 2026-08-09`. Once this merges, re-running the workflow will land the real numbers.

### Top 10 star movers (from run 31952458920)

| Repo | From | To | Δ |
|---|---:|---:|---:|
| earendil-works/pi | 85866 | 91248 | +5382 |
| NousResearch/hermes-agent | 227790 | 231340 | +3550 |
| obra/superpowers | 269582 | 272666 | +3084 |
| addyosmani/agent-skills | 84907 | 87645 | +2738 |
| anomalyco/opencode | 195322 | 197996 | +2674 |
| anthropics/skills | 167172 | 169674 | +2502 |
| can1357/oh-my-pi | 23205 | 25152 | +1947 |
| affaan-m/ECC | 238943 | 240393 | +1450 |
| openai/codex | 104910 | 106223 | +1313 |
| esengine/DeepSeek-Reasonix | 33360 | 34631 | +1271 |

### Rank movers >2 positions within a category

**Not computable this run.** `generate.py` never executed, so there is no regenerated `README.md` to diff. This will be reportable on the re-run.

### MOVED repos applied

None — `refresh_stars.py` reported no redirects this week.

### ARCHIVED / rebrand flags needing editorial review

Four repos now report archived. Three are carried over; **`FlowiseAI/Flowise` is new this week** and has not been triaged:

- `FlowiseAI/Flowise` ← **new, needs a curation call**
- `RooCodeInc/Roo-Code` (24,354 stars — archived since 2026-07-03)
- `spring-ai-community/spring-ai-tool-search-tool`
- `SeanHogg/BuilderForceAgents`

Per the CLAUDE.md curation bar these need either a flag in the description or removal. Roo-Code in particular is large enough that dropping it silently would be conspicuous.

### FAILED fetches

- `patronus-ai/trail-benchmark` — `HTTP Error 404: Not Found`. Old count kept. Likely deleted, renamed, or made private; worth confirming before the next run so it does not fail indefinitely.

### Routine repo scope

None — all tracked repos are in scope. `refresh_stars.py` reported `0 missing from routine scope`.

### Comparisons freshness

All 13 pages were last touched **2026-08-12 (4 days ago)**. **None exceed the 60-day threshold; no editorial review pass is needed this week.**

<details>
<summary>Per-page last-commit dates</summary>

| Page | Last commit |
|---|---|
| agent-eval-harnesses.md | 2026-08-12 |
| browser-agents.md | 2026-08-12 |
| browser-infrastructure.md | 2026-08-12 |
| claude-code-skill-packs.md | 2026-08-12 |
| eval-platforms.md | 2026-08-12 |
| how-to-pick-a-harness.md | 2026-08-12 |
| how-to-test-drive-a-harness.md | 2026-08-12 |
| memory-layers.md | 2026-08-12 |
| multi-agent-orchestration.md | 2026-08-12 |
| openclaw-vs-hermes.md | 2026-08-12 |
| progressive-disclosure.md | 2026-08-12 |
| sandboxed-code-execution.md | 2026-08-12 |
| terminal-coding-agents.md | 2026-08-12 |

</details>

### Weekly pulse — issues and PRs updated since 2026-08-09

Surfaced for triage, not acted on:

- **#81** Add project: MCP Lens — open, updated 2026-08-16, by `labmimors` — https://github.com/RyanAlberts/best-of-Agent-Harnesses/issues/81
- **#79** Add project: LWC (Local Wiki CLI) — open, updated 2026-08-15, by `JanYork` — https://github.com/RyanAlberts/best-of-Agent-Harnesses/issues/79
- **#75** Add project: Ouroboros — open, updated 2026-08-14, by `Q00` — https://github.com/RyanAlberts/best-of-Agent-Harnesses/issues/75
- **#74** Update project: Open Multi-Agent — open, updated 2026-08-10, by `JackChen-me` — https://github.com/RyanAlberts/best-of-Agent-Harnesses/issues/74
- **#76** Add project: Ouroboros — closed, updated 2026-08-10, by `Q00` (duplicate of #75) — https://github.com/RyanAlberts/best-of-Agent-Harnesses/issues/76

No maintainer corrections arrived via badge-outreach replies this week.

---

**Mechanics**

- [x] Changes are in CI config only — no generated files touched
- [x] `python3 -m pytest tests/ -q` → **54 passed**
- [x] Non-fatal semantics verified against a simulated 403: the traceback still reaches the log and execution continues to `generate.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_0189GTy1BbRVm3dwjWBJ6bgm)_