### PR TITLE
Don't fail the build when a researched project is archived upstream

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1942,6 +1942,20 @@ def load_deep_dives(attr_dir=None) -> dict:
     out, errors = {}, []
     by_slug = {project_slug(p.github_id): p.github_id
                for cat_id, _, _ in CATEGORIES for p in live_projects(cat_id)}
+    # Researched projects that have since been routed to the Graveyard keep
+    # their file on disk. Being archived upstream is not a research error, and
+    # generate_harnesses_json only ever reads deep dives for live_projects, so
+    # the entry is inert either way. Without this, the week a researched repo
+    # gets archived, refresh_stars.py adds it to ARCHIVED and the very next
+    # integrity check fails the build — which is exactly how the 2026-08-16
+    # rescore died on flowise.json. project_slug covers live projects only, so
+    # these are matched on the same base slug it derives.
+    graveyard_by_slug = {
+        (slug(p.github_id.split("/")[-1]) or slug(p.github_id.replace("/", "-"))):
+            p.github_id
+        for cat_id, _, _ in CATEGORIES for p in PROJECTS[cat_id]
+        if is_graveyard(p.github_id)
+    }
     for f in sorted(attr_dir.glob("*.json")):
         try:
             raw = json.loads(f.read_text())
@@ -1950,6 +1964,9 @@ def load_deep_dives(attr_dir=None) -> dict:
             continue
         gid = by_slug.get(f.stem)
         if gid is None or raw.get("github_id") != gid:
+            buried = graveyard_by_slug.get(f.stem)
+            if buried is not None and raw.get("github_id") == buried:
+                continue
             errors.append(f"{f.name}: no live project with slug {f.stem!r} and "
                           f"github_id {raw.get('github_id')!r}")
             continue


### PR DESCRIPTION
**What kind of change is this?**

- [ ] Add a project → fill in the intake below
- [ ] Correct a project I maintain (description / example link / tier / axes score)
- [x] Scripts, site, docs, or CI
- [ ] Other:

**Description:**

Second blocker on the 2026-08-16 rescore. With #83 merged, the traffic-snapshot 403 became a warning and [run 31955844160](https://github.com/RyanAlberts/best-of-Agent-Harnesses/actions/runs/31955844160) got further — through `discover_candidates.py` (110 candidates) and `generate.py` — then died on the integrity check:

```
attributes/ validation failed:
  flowise.json: no live project with slug 'flowise' and github_id 'FlowiseAI/Flowise'
```

`FlowiseAI/Flowise` was archived upstream this week. `refresh_stars.py` added it to `ARCHIVED`, `is_graveyard()` began returning True, and it dropped out of `live_projects()` — which is precisely what `ARCHIVED` is for. But `load_deep_dives()` validates every `attributes/*.json` against live projects only, so the now-orphaned research file failed the build.

**This trap is structural, not a one-off.** Any of the 87 researched projects archiving upstream breaks the following rescore. `roo-code.json` is in the same position today and escapes only because `RooCodeInc/Roo-Code` sits in `KEEP_DESPITE_ARCHIVED`.

Graveyard-routed projects are now matched against their own slug map and skipped. Archival upstream is not a research error, and `generate_harnesses_json()` reads deep dives only for `live_projects()`, so the entry was inert either way.

**The gate keeps its teeth.** Verified case by case against a live `generate` import:

| Case | Result |
|---|---|
| Baseline, Flowise live | deep dive still loaded ✅ |
| Flowise archived | build proceeds, not emitted ✅ |
| Unknown slug (`not-a-real-project.json`) | still rejected ✅ |
| Graveyard slug, mismatched `github_id` (`impostor/Flowise`) | still rejected ✅ |
| Graveyard slug, missing `github_id` | still rejected ✅ |

That last case needed an explicit `is not None` guard — without it a file with no `github_id` would have compared `None == None` against an absent slug and slipped through.

### Editorial call left open, on purpose

Whether `FlowiseAI/Flowise` belongs in the Graveyard (the pipeline's default for archived repos) or in `KEEP_DESPITE_ARCHIVED` alongside Roo-Code is a curation decision, and this PR does not make it. As written, the next rescore routes Flowise to the Graveyard. If it should stay in normal ordering the way Roo-Code does, add it to `KEEP_DESPITE_ARCHIVED` before the next run.

Three other repos remain flagged archived and untriaged: `RooCodeInc/Roo-Code` (kept deliberately), `spring-ai-community/spring-ai-tool-search-tool`, `SeanHogg/BuilderForceAgents`.

### Still outstanding from #83

`RESCORE_PAT` needs setting or renewing with admin/`repo` scope, or `traffic-history.jsonl` stops accumulating even though the rescore now completes. Also `patronus-ai/trail-benchmark` 404s on every run and should be re-pointed or dropped.

---

**Mechanics**

- [x] Change is in `scripts/generate.py`, not in generated files
- [x] `python3 scripts/generate.py` → output byte-identical, no generated file changed
- [x] `python3 scripts/check_integrity.py` → `integrity OK`
- [x] `python3 -m pytest tests/ -q` → **54 passed**

---
_Generated by [Claude Code](https://claude.ai/code/session_0189GTy1BbRVm3dwjWBJ6bgm)_