### PR TITLE
feat: add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-160-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-161-blue.svg?color=5ac4bf"></a>
     <a href="#for-agents" title="Agents can query this list — MCP server, llms.txt & JSON"><img src="https://img.shields.io/badge/agents-query%20this%20list-5ac4bf.svg"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
@@ -126,7 +126,7 @@ curl -fsSL https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses
 - [Evaluation and benchmarking harnesses](#evaluation-and-benchmarking-harnesses) _18 projects_
 - [Observability and eval-ops](#observability-and-eval-ops) _4 projects_
 - [Research and task-specific harnesses](#research-and-task-specific-harnesses) _5 projects_
-- [Libraries and SDKs](#libraries-and-sdks) _15 projects_
+- [Libraries and SDKs](#libraries-and-sdks) _16 projects_
 
 ## Guide to rankings
 
@@ -407,8 +407,9 @@ _Lightweight runtimes, tool loops, and provider-agnostic harness primitives._
 | 11 | <a name="agents-2"></a>[**Cloudflare Agents**](https://github.com/cloudflare/agents)&#8202;★&#8202;✱ | [5.4k](https://github.com/cloudflare/agents/stargazers) | Persistent, stateful agents on Durable Objects: state, websockets, scheduling, and AI chat baked in. The serverless answer to "where does the agent live?" <sup>`memory` · `typescript`</sup> | ✅ | slightly complex (Durable Objects, stateful) | [SDK playground app](https://github.com/cloudflare/agents/tree/main/examples/playground) |
 | 12 | <a name="openai-agents-js"></a>[**openai-agents-js**](https://github.com/openai/openai-agents-js) | [3.6k](https://github.com/openai/openai-agents-js/stargazers) | Official OpenAI Agents SDK for Node/TS: handoffs, guardrails, voice; the JS counterpart to openai-agents-python. <sup>`multi-agent` · `voice` · `typescript`</sup> | ✅ | slightly complex (handoffs, guardrails, voice) | [Financial research agent](https://github.com/openai/openai-agents-js/tree/main/examples/financial-research-agent) |
 | 13 | <a name="agent-sandbox"></a>[**Agent Sandbox**](https://github.com/kubernetes-sigs/agent-sandbox) | [3.5k](https://github.com/kubernetes-sigs/agent-sandbox/stargazers) | Kubernetes-native sandbox primitive for agent runtimes: a Sandbox resource plus warm pools and claims for fast-start, isolated, stateful workloads. The self-hosted answer to hosted sandbox APIs, from the Kubernetes SIGs org. <sup>`memory` · `sandbox` · `local`</sup> | ✅ | slightly complex (Kubernetes resource, warm pools) | [Sandbox resource quickstart](https://github.com/kubernetes-sigs/agent-sandbox#readme) |
-| 14 | <a name="open-harness"></a>[**open-harness**](https://github.com/MaxGfeller/open-harness) | [598](https://github.com/MaxGfeller/open-harness/stargazers) | TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation. <sup>`mcp` · `multi-agent` · `typescript`</sup> | ✅ | slightly complex (streaming, tools, subagents) | [Terminal CLI agent](https://github.com/MaxGfeller/open-harness/tree/main/examples/cli) |
-| 15 | <a name="awesome-ai-agents"></a>[**Community-curated agent lists**](https://github.com/brandonhimpfen/awesome-ai-agents) | [15](https://github.com/brandonhimpfen/awesome-ai-agents/stargazers) | Broader directories: e.g. [brandonhimpfen/awesome-ai-agents](https://github.com/brandonhimpfen/awesome-ai-agents), [axioma-ai-labs/awesome-ai-agent-frameworks](https://github.com/axioma-ai-labs/awesome-ai-agent-frameworks), [mb-mal/awesome-ai-agents-frameworks](https://github.com/mb-mal/awesome-ai-agents-frameworks)—differ by scope and update cadence. | ❓ | super simple (curated lists) | [Frameworks section](https://github.com/brandonhimpfen/awesome-ai-agents#frameworks) |
+| 14 | <a name="sandbase-harness"></a>[**SandBase Harness**](https://github.com/sandbaseai/sandbase-harness) | [621](https://github.com/sandbaseai/sandbase-harness/stargazers) | Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK. <sup>`mcp` · `memory` · `sandbox` · `typescript`</sup> | ✅ | complex (managed runtime, sandbox backends — product suite) | [DeepSeek Harness bridge](https://github.com/sandbaseai/sandbase-harness/tree/main/examples/deepseek-harness) |
+| 15 | <a name="open-harness"></a>[**open-harness**](https://github.com/MaxGfeller/open-harness) | [598](https://github.com/MaxGfeller/open-harness/stargazers) | TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation. <sup>`mcp` · `multi-agent` · `typescript`</sup> | ✅ | slightly complex (streaming, tools, subagents) | [Terminal CLI agent](https://github.com/MaxGfeller/open-harness/tree/main/examples/cli) |
+| 16 | <a name="awesome-ai-agents"></a>[**Community-curated agent lists**](https://github.com/brandonhimpfen/awesome-ai-agents) | [15](https://github.com/brandonhimpfen/awesome-ai-agents/stargazers) | Broader directories: e.g. [brandonhimpfen/awesome-ai-agents](https://github.com/brandonhimpfen/awesome-ai-agents), [axioma-ai-labs/awesome-ai-agent-frameworks](https://github.com/axioma-ai-labs/awesome-ai-agent-frameworks), [mb-mal/awesome-ai-agents-frameworks](https://github.com/mb-mal/awesome-ai-agents-frameworks)—differ by scope and update cadence. | ❓ | super simple (curated lists) | [Frameworks section](https://github.com/brandonhimpfen/awesome-ai-agents#frameworks) |
 
 ## ⚰️ Graveyard
 
@@ -453,7 +454,7 @@ Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n
 
 ### How many of these agent harnesses are open source?
 
-118 of 160 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+119 of 161 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable -->
 # Tags — cross-reference
 
-_Auto-generated from `scripts/generate.py`. 160 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
+_Auto-generated from `scripts/generate.py`. 161 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
 
 Tag chips appear next to each project in [README.md](README.md). This page lists every tag once with the projects that carry it, grouped by category and sorted by GitHub stars within each category.
 
 ## All tags
 
-[`mcp`](#mcp) (33) · [`memory`](#memory) (35) · [`multi-agent`](#multi-agent) (27) · [`evals`](#evals) (21) · [`voice`](#voice) (2) · [`vision`](#vision) (3) · [`browser`](#browser) (9) · [`sandbox`](#sandbox) (27) · [`low-code`](#low-code) (3) · [`rag`](#rag) (8) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (5) · [`workflow`](#workflow) (10) · [`typed`](#typed) (3) · [`local`](#local) (6) · [`provider-agnostic`](#provider-agnostic) (11) · [`cli`](#cli) (22) · [`ide`](#ide) (13) · [`tui`](#tui) (4) · [`rust`](#rust) (5) · [`python`](#python) (79) · [`typescript`](#typescript) (40)
+[`mcp`](#mcp) (34) · [`memory`](#memory) (36) · [`multi-agent`](#multi-agent) (27) · [`evals`](#evals) (21) · [`voice`](#voice) (2) · [`vision`](#vision) (3) · [`browser`](#browser) (9) · [`sandbox`](#sandbox) (28) · [`low-code`](#low-code) (3) · [`rag`](#rag) (8) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (5) · [`workflow`](#workflow) (10) · [`typed`](#typed) (3) · [`local`](#local) (6) · [`provider-agnostic`](#provider-agnostic) (11) · [`cli`](#cli) (22) · [`ide`](#ide) (13) · [`tui`](#tui) (4) · [`rust`](#rust) (5) · [`python`](#python) (79) · [`typescript`](#typescript) (41)
 
 ---
 
@@ -68,6 +68,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 
 - [pydantic-ai](https://github.com/pydantic/pydantic-ai) — ⭐19.3k — Type-safe Python agents with Pydantic I/O; multi-provider, MCP, Logfire observability, and human-in-the-loop.
 - [strands-agents](https://github.com/strands-agents/harness-sdk) — ⭐6.9k — Model-driven Python SDK; decorators for tools, native MCP, multi-agent; "minimal code" without sacrificing provider choice.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) — ⭐621 — Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.
 - [open-harness](https://github.com/MaxGfeller/open-harness) — ⭐598 — TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation.
 
 ---
@@ -138,6 +139,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [Steel](https://github.com/steel-dev/steel-browser) — ⭐7.5k — Open-source browser API for agents: cloud or self-hosted Chrome sessions with stealth, residential proxies, CAPTCHA solving, and persistent profiles. The only open-source core in the hosted browser-infrastructure lane (Browserbase and Hyperbrowser are closed).
 - [Cloudflare Agents](https://github.com/cloudflare/agents) — ⭐5.4k — Persistent, stateful agents on Durable Objects: state, websockets, scheduling, and AI chat baked in. The serverless answer to "where does the agent live?"
 - [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) — ⭐3.5k — Kubernetes-native sandbox primitive for agent runtimes: a Sandbox resource plus warm pools and claims for fast-start, isolated, stateful workloads. The self-hosted answer to hosted sandbox APIs, from the Kubernetes SIGs org.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) — ⭐621 — Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.
 
 ---
 
@@ -344,6 +346,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [deepagents](https://github.com/langchain-ai/deepagents) — ⭐27.8k — LangChain's Python+TypeScript agent harness on top of LangGraph: planning tool, virtual filesystem, shell sandbox, sub-agent spawning—the "Claude Code-style" harness as a reusable library.
 - [E2B](https://github.com/e2b-dev/E2B) — ⭐13.4k — Firecracker sandboxes for executing agent-generated code; the hosted isolation layer many tool-calling demos use instead of running arbitrary LLM output on your laptop.
 - [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) — ⭐3.5k — Kubernetes-native sandbox primitive for agent runtimes: a Sandbox resource plus warm pools and claims for fast-start, isolated, stateful workloads. The self-hosted answer to hosted sandbox APIs, from the Kubernetes SIGs org.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) — ⭐621 — Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.
 
 ---
 
@@ -796,6 +799,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [vercel/ai](https://github.com/vercel/ai) — ⭐26.2k — React and Node SDK for streaming, tool calls, and agent-style UIs; provider-agnostic.
 - [Cloudflare Agents](https://github.com/cloudflare/agents) — ⭐5.4k — Persistent, stateful agents on Durable Objects: state, websockets, scheduling, and AI chat baked in. The serverless answer to "where does the agent live?"
 - [openai-agents-js](https://github.com/openai/openai-agents-js) — ⭐3.6k — Official OpenAI Agents SDK for Node/TS: handoffs, guardrails, voice; the JS counterpart to openai-agents-python.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) — ⭐621 — Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.
 - [open-harness](https://github.com/MaxGfeller/open-harness) — ⭐598 — TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation.
 
 ---
@@ -986,4 +990,5 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [vercel/ai](https://github.com/vercel/ai) — ⭐26.2k — React and Node SDK for streaming, tool calls, and agent-style UIs; provider-agnostic.
 - [Cloudflare Agents](https://github.com/cloudflare/agents) — ⭐5.4k — Persistent, stateful agents on Durable Objects: state, websockets, scheduling, and AI chat baked in. The serverless answer to "where does the agent live?"
 - [openai-agents-js](https://github.com/openai/openai-agents-js) — ⭐3.6k — Official OpenAI Agents SDK for Node/TS: handoffs, guardrails, voice; the JS counterpart to openai-agents-python.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) — ⭐621 — Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.
 - [open-harness](https://github.com/MaxGfeller/open-harness) — ⭐598 — TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation.

--- a/assets/axes-grid.svg
+++ b/assets/axes-grid.svg
@@ -140,5 +140,5 @@
 <text x="993.7" y="164.6" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">n8n</text>
 <text x="1004.2" y="448.5" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">langflow</text>
 <text x="534.2" y="313.2" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">aider</text>
-<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">95 loop-owning projects shown · 65 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
+<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">95 loop-owning projects shown · 66 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
 </svg>

--- a/assets/landscape.svg
+++ b/assets/landscape.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 880" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
 <rect width="1320" height="880" fill="#ffffff" rx="8"/>
 <text x="660.0" y="52" text-anchor="middle" font-size="30" font-weight="700" fill="#111827">The Agent Harness Landscape</text>
-<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">160 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-08-16</text>
+<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">161 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-08-16</text>
 <circle cx="80" cy="106" r="6" fill="#8b5cf6"/>
 <text x="91" y="110" font-size="12.5" fill="#374151">Progressive disclosure</text>
 <circle cx="262.2" cy="106" r="6" fill="#ef4444"/>
@@ -47,7 +47,7 @@
 <text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">65 projects</text>
 <line x1="987.5" y1="168" x2="987.5" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="1138.8" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">complex</text>
-<text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">50 projects</text>
+<text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">51 projects</text>
 <line x1="80" y1="750" x2="1290" y2="750" stroke="#d1d5db" stroke-width="1.5"/>
 <text x="685.0" y="830" text-anchor="middle" font-size="13" fill="#6b7280">←  less to adopt: a file format, one concept&#160;&#160;·&#160;&#160;simplicity ↔ capability&#160;&#160;·&#160;&#160;full platforms with their own runtime: more to adopt  →</text>
 <circle cx="316.4" cy="749.9" r="4.5" fill="#10b981" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>agentlog — ⭐1</title></circle>
@@ -78,6 +78,7 @@
 <circle cx="876.9" cy="472.1" r="4.5" fill="#ef4444" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>claw-code-agent — ⭐543</title></circle>
 <circle cx="905.6" cy="471.2" r="4.5" fill="#8b5cf6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>langgraph-bigtool — ⭐554</title></circle>
 <circle cx="811.5" cy="467.4" r="4.5" fill="#a16207" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>open-harness — ⭐598</title></circle>
+<circle cx="1193.2" cy="465.5" r="4.5" fill="#a16207" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>SandBase Harness — ⭐621</title></circle>
 <circle cx="744.1" cy="465.0" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>inspect_evals — ⭐627</title></circle>
 <circle cx="914.7" cy="458.1" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>SWE-Gym — ⭐721</title></circle>
 <circle cx="256.8" cy="457.3" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>ARC-AGI-2 — ⭐733</title></circle>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -5,6 +5,6 @@
   <text x="140" y="184" font-family="Helvetica,Arial,sans-serif" font-size="32" fill="#5ac4bf" font-weight="700">best-of-Agent-Harnesses</text>
   <text x="80" y="300" font-family="Helvetica,Arial,sans-serif" font-size="74" fill="#f0f6fc" font-weight="800">Best of Agent Harnesses</text>
   <text x="80" y="378" font-family="Helvetica,Arial,sans-serif" font-size="38" fill="#9ca3af">The runtimes that close the loop between a model and the world.</text>
-  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">160 harnesses · 12 categories · MCP-ready · weekly-rescored</text>
+  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">161 harnesses · 12 categories · MCP-ready · weekly-rescored</text>
   <text x="80" y="566" font-family="Helvetica,Arial,sans-serif" font-size="27" fill="#9ca3af">github.com/RyanAlberts/best-of-Agent-Harnesses</text>
 </svg>

--- a/config/header.md
+++ b/config/header.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-160-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-161-blue.svg?color=5ac4bf"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
 </p>

--- a/feed.json
+++ b/feed.json
@@ -16,7 +16,7 @@
       "title": "Agent Harnesses list refreshed — 2026-08-16",
       "url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses",
       "date_published": "2026-08-16T00:00:00Z",
-      "content_text": "160 harnesses across 12 categories. Stars captured 2026-08-16. Most-starred: Headroom, awesome-cursorrules, agents.md, context-mode, langgraph-bigtool."
+      "content_text": "161 harnesses across 12 categories. Stars captured 2026-08-16. Most-starred: Headroom, awesome-cursorrules, agents.md, context-mode, langgraph-bigtool."
     },
     {
       "id": "refresh-2026-08-09",

--- a/harnesses.json
+++ b/harnesses.json
@@ -9,7 +9,7 @@
     "feed_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/feed.json",
     "license": "CC-BY-SA-4.0",
     "stars_captured": "2026-08-16",
-    "project_count": 160,
+    "project_count": 161,
     "graveyard_count": 4,
     "tiers": [
       "super simple",
@@ -375,7 +375,7 @@
     {
       "kind": "derived",
       "q": "How many of these agent harnesses are open source?",
-      "a": "118 of 160 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
+      "a": "119 of 161 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
       "slug": "how-many-of-these-agent-harnesses-are-open-source"
     },
     {
@@ -7863,6 +7863,37 @@
       "example": {
         "label": "Sandbox resource quickstart",
         "url": "https://github.com/kubernetes-sigs/agent-sandbox#readme"
+      },
+      "deep_dive": null
+    },
+    {
+      "name": "SandBase Harness",
+      "github_id": "sandbaseai/sandbase-harness",
+      "url": "https://github.com/sandbaseai/sandbase-harness",
+      "slug": "sandbase-harness",
+      "anchor_url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses#sandbase-harness",
+      "page_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/h/sandbase-harness/",
+      "description": "Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.",
+      "category": "libraries-sdks",
+      "category_title": "Libraries and SDKs",
+      "stars": 621,
+      "tier": "complex",
+      "tier_rank": 4,
+      "axis": "complex (managed runtime, sandbox backends — product suite)",
+      "autonomy": "n/a",
+      "autonomy_rank": 0,
+      "recovery": "n/a",
+      "recovery_rank": 0,
+      "license_signal": "open-source",
+      "tags": [
+        "mcp",
+        "memory",
+        "sandbox",
+        "typescript"
+      ],
+      "example": {
+        "label": "DeepSeek Harness bridge",
+        "url": "https://github.com/sandbaseai/sandbase-harness/tree/main/examples/deepseek-harness"
       },
       "deep_dive": null
     },

--- a/harnesses.jsonld
+++ b/harnesses.jsonld
@@ -29,7 +29,7 @@
   ],
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": 160,
+    "numberOfItems": 161,
     "itemListElement": [
       {
         "@type": "ListItem",
@@ -1932,6 +1932,18 @@
         "position": 159,
         "item": {
           "@type": "SoftwareApplication",
+          "name": "SandBase Harness",
+          "url": "https://github.com/sandbaseai/sandbase-harness",
+          "description": "Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.",
+          "applicationCategory": "DeveloperApplication",
+          "keywords": "mcp, memory, sandbox, typescript"
+        }
+      },
+      {
+        "@type": "ListItem",
+        "position": 160,
+        "item": {
+          "@type": "SoftwareApplication",
           "name": "open-harness",
           "url": "https://github.com/MaxGfeller/open-harness",
           "description": "TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation.",
@@ -1941,7 +1953,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 160,
+        "position": 161,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Community-curated agent lists",

--- a/landscape.md
+++ b/landscape.md
@@ -1,6 +1,6 @@
 # The agent harness landscape, in two charts
 
-Both charts plot every project in [best-of-Agent-Harnesses](README.md), a curated list of 160 agent harnesses: the runtimes that turn an AI model into a working agent. They regenerate from the list data on every weekly refresh, so what you see is current.
+Both charts plot every project in [best-of-Agent-Harnesses](README.md), a curated list of 161 agent harnesses: the runtimes that turn an AI model into a working agent. They regenerate from the list data on every weekly refresh, so what you see is current.
 
 ## Adoption surface vs. stars
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Best of Agent Harnesses
 
-> Hand-curated, ranked list of 160 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 12 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-08-16.
+> Hand-curated, ranked list of 161 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 12 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-08-16.
 
 Maintained at https://github.com/RyanAlberts/best-of-Agent-Harnesses (CC-BY-SA-4.0).
 Structured data: https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses/main/harnesses.json
@@ -90,7 +90,7 @@ Harnesses designed for unattended runs, batches, and fleets: opencode, OpenHands
 Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n, langgraph, mastra, letta, deepagents, pydantic-ai, Cloudflare Agents.
 
 ### How many of these agent harnesses are open source?
-118 of 160 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+119 of 161 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 The runtime that turns a model into an agent: it decides what the model's reasoning is allowed to touch, and supplies the orchestration, tool wiring, memory, error recovery, and guardrails around per-turn inference.
@@ -301,7 +301,7 @@ Deep research, document QA, and domain-specific agent loops.
 - [MiroThinker](https://github.com/MiroMindAI/MiroThinker) — ⭐8.4k, slightly complex, autonomy: headless, recovery: retry, unknown: Deep-research **harness** tuned for long browsing-and-reasoning chains; benchmarked on BrowseComp, GAIA, and HLE by pairing a dedicated agent loop with its own MiroThinker models rather than bolting search onto a generic chat agent. [evals]
 - [openagents](https://github.com/OpenAgentsInc/openagents) — ⭐446, complex, autonomy: headless, recovery: resumable, open-source: Platform for autonomous agents and autopilot-style workflows; decentralized/Nostr-oriented (Pylon runtime, actively shipped in 2026).
 
-## Libraries and SDKs (15 projects)
+## Libraries and SDKs (16 projects)
 
 Lightweight runtimes, tool loops, and provider-agnostic harness primitives.
 
@@ -318,5 +318,6 @@ Lightweight runtimes, tool loops, and provider-agnostic harness primitives.
 - [Cloudflare Agents](https://github.com/cloudflare/agents) — ⭐5.4k, slightly complex, autonomy: headless, recovery: durable, open-source: Persistent, stateful agents on Durable Objects: state, websockets, scheduling, and AI chat baked in. The serverless answer to "where does the agent live?" [memory, typescript]
 - [openai-agents-js](https://github.com/openai/openai-agents-js) — ⭐3.6k, slightly complex, autonomy: bounded, recovery: resumable, open-source: Official OpenAI Agents SDK for Node/TS: handoffs, guardrails, voice; the JS counterpart to openai-agents-python. [multi-agent, voice, typescript]
 - [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) — ⭐3.5k, slightly complex, autonomy: n/a, recovery: n/a, open-source: Kubernetes-native sandbox primitive for agent runtimes: a Sandbox resource plus warm pools and claims for fast-start, isolated, stateful workloads. The self-hosted answer to hosted sandbox APIs, from the Kubernetes SIGs org. [memory, sandbox, local]
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) — ⭐621, complex, autonomy: n/a, recovery: n/a, open-source: Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK. [mcp, memory, sandbox, typescript]
 - [open-harness](https://github.com/MaxGfeller/open-harness) — ⭐598, slightly complex, autonomy: bounded, recovery: none, open-source: TypeScript Agent class on Vercel AI SDK; streaming events, filesystem/bash tools, MCP, and subagent delegation. [mcp, multi-agent, typescript]
 - [Community-curated agent lists](https://github.com/brandonhimpfen/awesome-ai-agents) — ⭐15, super simple, autonomy: n/a, recovery: n/a, unknown: Broader directories: e.g. [brandonhimpfen/awesome-ai-agents](https://github.com/brandonhimpfen/awesome-ai-agents), [axioma-ai-labs/awesome-ai-agent-frameworks](https://github.com/axioma-ai-labs/awesome-ai-agent-frameworks), [mb-mal/awesome-ai-agents-frameworks](https://github.com/mb-mal/awesome-ai-agents-frameworks)—differ by scope and update cadence.

--- a/projects.yaml
+++ b/projects.yaml
@@ -604,6 +604,10 @@ projects:
     github_id: aiming-lab/AutoResearchClaw
     category: "research-task"
   # Libraries and SDKs
+  - name: SandBase Harness
+    github_id: sandbaseai/sandbase-harness
+    labels: ["javascript"]
+    category: "libraries-sdks"
   - name: deepagents
     github_id: langchain-ai/deepagents
     labels: ["python"]

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -616,6 +616,9 @@ PROJECTS: dict[str, list[Project]] = {
                 "complex (autonomous research, multi-agent debate — product suite)", oss="❓"),
     ],
     "libraries-sdks": [
+        Project("SandBase Harness", "sandbaseai/sandbase-harness",
+                "Local-first runtime layer for AI agents: persistent sessions, MCP toolsets, permission policies, memory, audit trails, and local/Docker/Kubernetes sandbox boundaries behind a Claude Managed Agents-style API. The **harness** contribution is the governed execution and session substrate around an SDK-owned model loop, not another model SDK.",
+                "complex (managed runtime, sandbox backends — product suite)", labels=["javascript"]),
         Project("deepagents", "langchain-ai/deepagents",
                 "LangChain's Python+TypeScript agent harness on top of LangGraph: planning tool, virtual filesystem, shell sandbox, sub-agent spawning—the \"Claude Code-style\" harness as a reusable library.",
                 "slightly complex (planning, files, sub-agents)", labels=["python"]),
@@ -815,6 +818,7 @@ META: dict[str, tuple[int, str, str]] = {
     "MiroMindAI/MiroThinker": (8357, "https://github.com/MiroMindAI/MiroThinker#readme", "Project README"),
     "aiming-lab/AutoResearchClaw": (14029, "https://github.com/aiming-lab/AutoResearchClaw#readme", "Project README"),
     # libraries-sdks
+    "sandbaseai/sandbase-harness": (621, "https://github.com/sandbaseai/sandbase-harness/tree/main/examples/deepseek-harness", "DeepSeek Harness bridge"),
     "langchain-ai/deepagents": (27811, "https://github.com/langchain-ai/deepagents/tree/main/examples/deep_research", "Deep research agent"),
     "pydantic/pydantic-ai": (19331, "https://github.com/pydantic/pydantic-ai/blob/main/examples/pydantic_ai_examples/bank_support.py", "Bank support agent"),
     "MaxGfeller/open-harness": (598, "https://github.com/MaxGfeller/open-harness/tree/main/examples/cli", "Terminal CLI agent"),
@@ -1195,6 +1199,7 @@ AXES: "dict[str, tuple[str, str]]" = {
     "ComposioHQ/composio": ("n/a", "n/a"),
     "huggingface/smolagents": ("bounded", "none"),
     "vercel/ai": ("bounded", "retry"),
+    "sandbaseai/sandbase-harness": ("n/a", "n/a"),
     "langchain-ai/deepagents": ("bounded", "durable"),
     "pydantic/pydantic-ai": ("bounded", "durable"),
     "e2b-dev/E2B": ("n/a", "n/a"),


### PR DESCRIPTION
## Summary

- add SandBase Harness to Libraries and SDKs
- describe its governed runtime contribution around SDK-owned model loops
- add current metadata, behavior axes, and the DeepSeek Harness bridge example
- regenerate all derived catalog and visualization files

## Validation

- `python3 scripts/generate.py`
- `python3 -m pytest tests/ -q` (54 passed)
- `git diff --check`

Disclosure: I am contributing on behalf of the SandBase project.