### PR TITLE
Add YYLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-160-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-161-blue.svg?color=5ac4bf"></a>
     <a href="#for-agents" title="Agents can query this list — MCP server, llms.txt & JSON"><img src="https://img.shields.io/badge/agents-query%20this%20list-5ac4bf.svg"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
@@ -116,7 +116,7 @@ curl -fsSL https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses
 - [For agents: harnesses.json, llms.txt, MCP server, agent templates](#for-agents)
 - [FAQ](#faq)
 - [Progressive disclosure harnesses](#progressive-disclosure-harnesses) _8 projects_
-- [Coding agent products (IDEs, CLIs, full suites)](#coding-agent-products-ides-clis-full-suites) _22 projects_
+- [Coding agent products (IDEs, CLIs, full suites)](#coding-agent-products-ides-clis-full-suites) _23 projects_
 - [Coding harness configs and SDKs](#coding-harness-configs-and-sdks) _17 projects_
 - [Personal agent runtimes](#personal-agent-runtimes) _10 projects_
 - [Frameworks](#frameworks) _25 projects_
@@ -189,6 +189,7 @@ _Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Docke
 | 20 | <a name="claw-code-agent"></a>[**claw-code-agent**](https://github.com/HarnessLab/claw-code-agent) | [544](https://github.com/HarnessLab/claw-code-agent/stargazers) | Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. <sup>`mcp` · `rust` · `python` · `typescript`</sup> | ❓ | slightly complex (pure Python, plugin runtime) | [Quick Start guide](https://github.com/HarnessLab/claw-code-agent#-quick-start) |
 | 21 | <a name="proliferate"></a>[**Proliferate**](https://github.com/proliferate-ai/proliferate) | [463](https://github.com/proliferate-ai/proliferate/stargazers) | Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context. <sup>`multi-agent` · `sandbox` · `ide` · `typescript`</sup> | ✅ | complex (multi-agent workspace orchestration — product suite) | [Product README](https://github.com/proliferate-ai/proliferate#readme) |
 | 22 | <a name="agentbox"></a>[**AgentBox**](https://github.com/madarco/agentbox) | [387](https://github.com/madarco/agentbox/stargazers) | Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop. <sup>`sandbox` · `typescript`</sup> | ✅ | slightly complex (VM-per-agent sandbox, parallel fan-out) | [Parallel agents quick start](https://github.com/madarco/agentbox#readme) |
+| 23 | <a name="yylo"></a>[**YYLO**](https://github.com/yylo-dev/yylo) | [57](https://github.com/yylo-dev/yylo/stargazers) | Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself. <sup>`multi-agent` · `typescript`</sup> | ✅ | slightly complex (git-native task fleet, merge queue) | [Project README](https://github.com/yylo-dev/yylo#readme) |
 
 ## Coding harness configs and SDKs
 
@@ -453,7 +454,7 @@ Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n
 
 ### How many of these agent harnesses are open source?
 
-118 of 160 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+119 of 161 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable -->
 # Tags — cross-reference
 
-_Auto-generated from `scripts/generate.py`. 160 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
+_Auto-generated from `scripts/generate.py`. 161 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
 
 Tag chips appear next to each project in [README.md](README.md). This page lists every tag once with the projects that carry it, grouped by category and sorted by GitHub stars within each category.
 
 ## All tags
 
-[`mcp`](#mcp) (33) · [`memory`](#memory) (35) · [`multi-agent`](#multi-agent) (27) · [`evals`](#evals) (21) · [`voice`](#voice) (2) · [`vision`](#vision) (3) · [`browser`](#browser) (9) · [`sandbox`](#sandbox) (27) · [`low-code`](#low-code) (3) · [`rag`](#rag) (8) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (5) · [`workflow`](#workflow) (10) · [`typed`](#typed) (3) · [`local`](#local) (6) · [`provider-agnostic`](#provider-agnostic) (11) · [`cli`](#cli) (22) · [`ide`](#ide) (13) · [`tui`](#tui) (4) · [`rust`](#rust) (5) · [`python`](#python) (79) · [`typescript`](#typescript) (40)
+[`mcp`](#mcp) (33) · [`memory`](#memory) (35) · [`multi-agent`](#multi-agent) (28) · [`evals`](#evals) (21) · [`voice`](#voice) (2) · [`vision`](#vision) (3) · [`browser`](#browser) (9) · [`sandbox`](#sandbox) (27) · [`low-code`](#low-code) (3) · [`rag`](#rag) (8) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (5) · [`workflow`](#workflow) (10) · [`typed`](#typed) (3) · [`local`](#local) (6) · [`provider-agnostic`](#provider-agnostic) (11) · [`cli`](#cli) (22) · [`ide`](#ide) (13) · [`tui`](#tui) (4) · [`rust`](#rust) (5) · [`python`](#python) (79) · [`typescript`](#typescript) (41)
 
 ---
 
@@ -148,6 +148,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [eigent](https://github.com/eigent-ai/eigent) — ⭐15.2k — Open-source desktop **harness** positioned as a local, free alternative to Claude Cowork and Codex: multi-agent workspace orchestration in a self-hosted app rather than a hosted product.
 - [cc-haha](https://github.com/NanmiCoder/cc-haha) — ⭐14.3k — Local-first desktop workspace **harness** for Claude Code and other agents: multi-agent sessions, Git worktrees, code diffs, a skill marketplace, and chat-app access (WeChat, Telegram, WhatsApp).
 - [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐463 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
+- [YYLO](https://github.com/yylo-dev/yylo) — ⭐57 — Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself.
 
 **Coding harness configs and SDKs**
 
@@ -748,6 +749,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐544 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 - [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐463 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐387 — Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop.
+- [YYLO](https://github.com/yylo-dev/yylo) — ⭐57 — Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself.
 
 **Coding harness configs and SDKs**
 
@@ -938,6 +940,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐544 — Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain.
 - [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐463 — Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context.
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐387 — Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop.
+- [YYLO](https://github.com/yylo-dev/yylo) — ⭐57 — Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself.
 
 **Coding harness configs and SDKs**
 

--- a/assets/axes-grid.svg
+++ b/assets/axes-grid.svg
@@ -140,5 +140,5 @@
 <text x="993.7" y="164.6" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">n8n</text>
 <text x="913.1" y="500.7" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">Dify</text>
 <text x="534.2" y="313.2" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">aider</text>
-<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">95 loop-owning projects shown · 65 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
+<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">95 loop-owning projects shown · 66 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
 </svg>

--- a/assets/landscape.svg
+++ b/assets/landscape.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 880" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
 <rect width="1320" height="880" fill="#ffffff" rx="8"/>
 <text x="660.0" y="52" text-anchor="middle" font-size="30" font-weight="700" fill="#111827">The Agent Harness Landscape</text>
-<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">160 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-09-06</text>
+<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">161 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-09-06</text>
 <circle cx="80" cy="106" r="6" fill="#8b5cf6"/>
 <text x="91" y="110" font-size="12.5" fill="#374151">Progressive disclosure</text>
 <circle cx="262.2" cy="106" r="6" fill="#ef4444"/>
@@ -44,7 +44,7 @@
 <text x="533.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">33 projects</text>
 <line x1="685.0" y1="168" x2="685.0" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="836.2" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">slightly complex</text>
-<text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">65 projects</text>
+<text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">66 projects</text>
 <line x1="987.5" y1="168" x2="987.5" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="1138.8" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">complex</text>
 <text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">50 projects</text>
@@ -57,6 +57,7 @@
 <circle cx="549.0" cy="631.0" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>TRAIL — ⭐22</title></circle>
 <circle cx="466.0" cy="622.8" r="4.5" fill="#10b981" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>puppeteer-real-browser-mcp — ⭐26</title></circle>
 <circle cx="598.0" cy="610.9" r="4.5" fill="#8b5cf6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>ToolRAG — ⭐33</title></circle>
+<circle cx="865.1" cy="583.9" r="4.5" fill="#ef4444" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>YYLO — ⭐57</title></circle>
 <circle cx="845.0" cy="583.0" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>SUPER — ⭐58</title></circle>
 <circle cx="811.5" cy="570.3" r="4.5" fill="#0ea5e9" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Talon — ⭐75</title></circle>
 <circle cx="489.2" cy="565.8" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>letta-evals — ⭐82</title></circle>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -5,6 +5,6 @@
   <text x="140" y="184" font-family="Helvetica,Arial,sans-serif" font-size="32" fill="#5ac4bf" font-weight="700">best-of-Agent-Harnesses</text>
   <text x="80" y="300" font-family="Helvetica,Arial,sans-serif" font-size="74" fill="#f0f6fc" font-weight="800">Best of Agent Harnesses</text>
   <text x="80" y="378" font-family="Helvetica,Arial,sans-serif" font-size="38" fill="#9ca3af">The runtimes that close the loop between a model and the world.</text>
-  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">160 harnesses · 12 categories · MCP-ready · weekly-rescored</text>
+  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">161 harnesses · 12 categories · MCP-ready · weekly-rescored</text>
   <text x="80" y="566" font-family="Helvetica,Arial,sans-serif" font-size="27" fill="#9ca3af">github.com/RyanAlberts/best-of-Agent-Harnesses</text>
 </svg>

--- a/config/header.md
+++ b/config/header.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-160-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-161-blue.svg?color=5ac4bf"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
 </p>

--- a/feed.json
+++ b/feed.json
@@ -16,7 +16,7 @@
       "title": "Agent Harnesses list refreshed — 2026-09-06",
       "url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses",
       "date_published": "2026-09-06T00:00:00Z",
-      "content_text": "160 harnesses across 12 categories. Stars captured 2026-09-06. Most-starred: Headroom, awesome-cursorrules, agents.md, context-mode, langgraph-bigtool."
+      "content_text": "161 harnesses across 12 categories. Stars captured 2026-09-06. Most-starred: Headroom, awesome-cursorrules, agents.md, context-mode, langgraph-bigtool."
     },
     {
       "id": "refresh-2026-08-30",

--- a/harnesses.json
+++ b/harnesses.json
@@ -9,7 +9,7 @@
     "feed_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/feed.json",
     "license": "CC-BY-SA-4.0",
     "stars_captured": "2026-09-06",
-    "project_count": 160,
+    "project_count": 161,
     "graveyard_count": 4,
     "tiers": [
       "super simple",
@@ -375,7 +375,7 @@
     {
       "kind": "derived",
       "q": "How many of these agent harnesses are open source?",
-      "a": "118 of 160 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
+      "a": "119 of 161 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
       "slug": "how-many-of-these-agent-harnesses-are-open-source"
     },
     {
@@ -2183,6 +2183,35 @@
           "evidence": "https://github.com/madarco/agentbox"
         }
       }
+    },
+    {
+      "name": "YYLO",
+      "github_id": "yylo-dev/yylo",
+      "url": "https://github.com/yylo-dev/yylo",
+      "slug": "yylo",
+      "anchor_url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses#yylo",
+      "page_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/h/yylo/",
+      "description": "Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself.",
+      "category": "coding-agent-products",
+      "category_title": "Coding agent products (IDEs, CLIs, full suites)",
+      "stars": 57,
+      "tier": "slightly complex",
+      "tier_rank": 3,
+      "axis": "slightly complex (git-native task fleet, merge queue)",
+      "autonomy": "n/a",
+      "autonomy_rank": 0,
+      "recovery": "n/a",
+      "recovery_rank": 0,
+      "license_signal": "open-source",
+      "tags": [
+        "multi-agent",
+        "typescript"
+      ],
+      "example": {
+        "label": "Project README",
+        "url": "https://github.com/yylo-dev/yylo#readme"
+      },
+      "deep_dive": null
     },
     {
       "name": "superpowers",

--- a/harnesses.jsonld
+++ b/harnesses.jsonld
@@ -29,7 +29,7 @@
   ],
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": 160,
+    "numberOfItems": 161,
     "itemListElement": [
       {
         "@type": "ListItem",
@@ -396,6 +396,18 @@
         "position": 31,
         "item": {
           "@type": "SoftwareApplication",
+          "name": "YYLO",
+          "url": "https://github.com/yylo-dev/yylo",
+          "description": "Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself.",
+          "applicationCategory": "DeveloperApplication",
+          "keywords": "multi-agent, typescript"
+        }
+      },
+      {
+        "@type": "ListItem",
+        "position": 32,
+        "item": {
+          "@type": "SoftwareApplication",
           "name": "superpowers",
           "url": "https://github.com/obra/superpowers",
           "description": "Performance-oriented harness pack for Claude Code and 13 other harnesses (Codex, Cursor, OpenCode, Gemini CLI, more): skills, instincts, memory, security, research-first workflows. Treats harness engineering itself as the performance lever.",
@@ -405,7 +417,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 32,
+        "position": 33,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Anthropic Skills",
@@ -417,7 +429,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 33,
+        "position": 34,
         "item": {
           "@type": "SoftwareApplication",
           "name": "GStack",
@@ -429,7 +441,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 34,
+        "position": 35,
         "item": {
           "@type": "SoftwareApplication",
           "name": "addyosmani/agent-skills",
@@ -441,7 +453,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 35,
+        "position": 36,
         "item": {
           "@type": "SoftwareApplication",
           "name": "awesome-claude-code",
@@ -453,7 +465,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 36,
+        "position": 37,
         "item": {
           "@type": "SoftwareApplication",
           "name": "wshobson/agents",
@@ -465,7 +477,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 37,
+        "position": 38,
         "item": {
           "@type": "SoftwareApplication",
           "name": "planning-with-files",
@@ -477,7 +489,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 38,
+        "position": 39,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-agent",
@@ -489,7 +501,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 39,
+        "position": 40,
         "item": {
           "@type": "SoftwareApplication",
           "name": "get-shit-done",
@@ -501,7 +513,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 40,
+        "position": 41,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Claude Agent SDK",
@@ -513,7 +525,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 41,
+        "position": 42,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agents-cli",
@@ -525,7 +537,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 42,
+        "position": 43,
         "item": {
           "@type": "SoftwareApplication",
           "name": "skillhub",
@@ -537,7 +549,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 43,
+        "position": 44,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Meta-Harness",
@@ -549,7 +561,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 44,
+        "position": 45,
         "item": {
           "@type": "SoftwareApplication",
           "name": "RepoMaster",
@@ -561,7 +573,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 45,
+        "position": 46,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoHarness",
@@ -573,7 +585,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 46,
+        "position": 47,
         "item": {
           "@type": "SoftwareApplication",
           "name": "LoopTroop",
@@ -585,7 +597,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 47,
+        "position": 48,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pmstack",
@@ -597,7 +609,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 48,
+        "position": 49,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenClaw",
@@ -609,7 +621,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 49,
+        "position": 50,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Hermes",
@@ -621,7 +633,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 50,
+        "position": 51,
         "item": {
           "@type": "SoftwareApplication",
           "name": "nanobot",
@@ -633,7 +645,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 51,
+        "position": 52,
         "item": {
           "@type": "SoftwareApplication",
           "name": "CowAgent",
@@ -645,7 +657,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 52,
+        "position": 53,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Khoj",
@@ -657,7 +669,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 53,
+        "position": 54,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Eliza",
@@ -669,7 +681,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 54,
+        "position": 55,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Zero",
@@ -681,7 +693,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 55,
+        "position": 56,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenHarness (HKUDS)",
@@ -693,7 +705,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 56,
+        "position": 57,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AIlice",
@@ -705,7 +717,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 57,
+        "position": 58,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Talon",
@@ -717,7 +729,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 58,
+        "position": 59,
         "item": {
           "@type": "SoftwareApplication",
           "name": "n8n",
@@ -729,7 +741,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 59,
+        "position": 60,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoGPT",
@@ -741,7 +753,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 60,
+        "position": 61,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Dify",
@@ -753,7 +765,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 61,
+        "position": 62,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langflow",
@@ -765,7 +777,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 62,
+        "position": 63,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langchain",
@@ -777,7 +789,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 63,
+        "position": 64,
         "item": {
           "@type": "SoftwareApplication",
           "name": "browser-use",
@@ -789,7 +801,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 64,
+        "position": 65,
         "item": {
           "@type": "SoftwareApplication",
           "name": "llama-index",
@@ -801,7 +813,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 65,
+        "position": 66,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agno",
@@ -813,7 +825,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 66,
+        "position": 67,
         "item": {
           "@type": "SoftwareApplication",
           "name": "langgraph",
@@ -825,7 +837,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 67,
+        "position": 68,
         "item": {
           "@type": "SoftwareApplication",
           "name": "semantic-kernel",
@@ -837,7 +849,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 68,
+        "position": 69,
         "item": {
           "@type": "SoftwareApplication",
           "name": "mastra",
@@ -849,7 +861,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 69,
+        "position": 70,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Haystack",
@@ -861,7 +873,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 70,
+        "position": 71,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta",
@@ -873,7 +885,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 71,
+        "position": 72,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Stagehand",
@@ -885,7 +897,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 72,
+        "position": 73,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Google ADK",
@@ -897,7 +909,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 73,
+        "position": 74,
         "item": {
           "@type": "SoftwareApplication",
           "name": "rasa",
@@ -909,7 +921,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 74,
+        "position": 75,
         "item": {
           "@type": "SoftwareApplication",
           "name": "botpress",
@@ -921,7 +933,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 75,
+        "position": 76,
         "item": {
           "@type": "SoftwareApplication",
           "name": "R2R",
@@ -933,7 +945,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 76,
+        "position": 77,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-squad",
@@ -945,7 +957,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 77,
+        "position": 78,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentVerse",
@@ -957,7 +969,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 78,
+        "position": 79,
         "item": {
           "@type": "SoftwareApplication",
           "name": "youtu-agent",
@@ -969,7 +981,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 79,
+        "position": 80,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Bee Agent Framework",
@@ -981,7 +993,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 80,
+        "position": 81,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentStack",
@@ -993,7 +1005,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 81,
+        "position": 82,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentSilex",
@@ -1005,7 +1017,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 82,
+        "position": 83,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SuperAgentX",
@@ -1017,7 +1029,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 83,
+        "position": 84,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MetaGPT",
@@ -1029,7 +1041,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 84,
+        "position": 85,
         "item": {
           "@type": "SoftwareApplication",
           "name": "autogen",
@@ -1041,7 +1053,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 85,
+        "position": 86,
         "item": {
           "@type": "SoftwareApplication",
           "name": "OpenManus",
@@ -1053,7 +1065,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 86,
+        "position": 87,
         "item": {
           "@type": "SoftwareApplication",
           "name": "crewAI",
@@ -1065,7 +1077,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 87,
+        "position": 88,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ChatDev",
@@ -1077,7 +1089,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 88,
+        "position": 89,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-python",
@@ -1089,7 +1101,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 89,
+        "position": 90,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Microsoft Agent Framework",
@@ -1101,7 +1113,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 90,
+        "position": 91,
         "item": {
           "@type": "SoftwareApplication",
           "name": "hive",
@@ -1113,7 +1125,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 91,
+        "position": 92,
         "item": {
           "@type": "SoftwareApplication",
           "name": "omnigent",
@@ -1125,7 +1137,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 92,
+        "position": 93,
         "item": {
           "@type": "SoftwareApplication",
           "name": "PraisonAI",
@@ -1137,7 +1149,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 93,
+        "position": 94,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AG2",
@@ -1149,7 +1161,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 94,
+        "position": 95,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentRL",
@@ -1161,7 +1173,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 95,
+        "position": 96,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Servers",
@@ -1173,7 +1185,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 96,
+        "position": 97,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Context7",
@@ -1185,7 +1197,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 97,
+        "position": 98,
         "item": {
           "@type": "SoftwareApplication",
           "name": "chrome-devtools-mcp",
@@ -1197,7 +1209,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 98,
+        "position": 99,
         "item": {
           "@type": "SoftwareApplication",
           "name": "aider",
@@ -1209,7 +1221,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 99,
+        "position": 100,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Playwright MCP",
@@ -1221,7 +1233,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 100,
+        "position": 101,
         "item": {
           "@type": "SoftwareApplication",
           "name": "continue",
@@ -1233,7 +1245,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 101,
+        "position": 102,
         "item": {
           "@type": "SoftwareApplication",
           "name": "github-mcp-server",
@@ -1245,7 +1257,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 102,
+        "position": 103,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Python SDK",
@@ -1257,7 +1269,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 103,
+        "position": 104,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP TypeScript SDK",
@@ -1269,7 +1281,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 104,
+        "position": 105,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Inspector",
@@ -1281,7 +1293,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 105,
+        "position": 106,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MCP Registry",
@@ -1293,7 +1305,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 106,
+        "position": 107,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Governance Toolkit",
@@ -1305,7 +1317,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 107,
+        "position": 108,
         "item": {
           "@type": "SoftwareApplication",
           "name": "mcp-context-forge",
@@ -1317,7 +1329,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 108,
+        "position": 109,
         "item": {
           "@type": "SoftwareApplication",
           "name": "cocoindex-code",
@@ -1329,7 +1341,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 109,
+        "position": 110,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-vault",
@@ -1341,7 +1353,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 110,
+        "position": 111,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Docker MCP Gateway",
@@ -1353,7 +1365,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 111,
+        "position": 112,
         "item": {
           "@type": "SoftwareApplication",
           "name": "puppeteer-real-browser-mcp",
@@ -1365,7 +1377,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 112,
+        "position": 113,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Better-OpenCodeMCP",
@@ -1377,7 +1389,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 113,
+        "position": 114,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agentlog",
@@ -1389,7 +1401,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 114,
+        "position": 115,
         "item": {
           "@type": "SoftwareApplication",
           "name": "claude-mem",
@@ -1401,7 +1413,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 115,
+        "position": 116,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Mem0",
@@ -1413,7 +1425,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 116,
+        "position": 117,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Graphiti (Zep)",
@@ -1425,7 +1437,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 117,
+        "position": 118,
         "item": {
           "@type": "SoftwareApplication",
           "name": "cognee",
@@ -1437,7 +1449,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 118,
+        "position": 119,
         "item": {
           "@type": "SoftwareApplication",
           "name": "beads",
@@ -1449,7 +1461,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 119,
+        "position": 120,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Lightning",
@@ -1461,7 +1473,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 120,
+        "position": 121,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-bench",
@@ -1473,7 +1485,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 121,
+        "position": 122,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentBench",
@@ -1485,7 +1497,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 122,
+        "position": 123,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_ai",
@@ -1497,7 +1509,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 123,
+        "position": 124,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebArena",
@@ -1509,7 +1521,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 124,
+        "position": 125,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebVoyager",
@@ -1521,7 +1533,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 125,
+        "position": 126,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-qa",
@@ -1533,7 +1545,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 126,
+        "position": 127,
         "item": {
           "@type": "SoftwareApplication",
           "name": "swe-smith",
@@ -1545,7 +1557,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 127,
+        "position": 128,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ARC-AGI-2",
@@ -1557,7 +1569,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 128,
+        "position": 129,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-Gym",
@@ -1569,7 +1581,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 129,
+        "position": 130,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_evals",
@@ -1581,7 +1593,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 130,
+        "position": 131,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Terminal-Bench",
@@ -1593,7 +1605,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 131,
+        "position": 132,
         "item": {
           "@type": "SoftwareApplication",
           "name": "arc-agi-benchmarking",
@@ -1605,7 +1617,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 132,
+        "position": 133,
         "item": {
           "@type": "SoftwareApplication",
           "name": "VitaBench",
@@ -1617,7 +1629,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 133,
+        "position": 134,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgencyBench",
@@ -1629,7 +1641,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 134,
+        "position": 135,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta-evals",
@@ -1641,7 +1653,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 135,
+        "position": 136,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SUPER",
@@ -1653,7 +1665,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 136,
+        "position": 137,
         "item": {
           "@type": "SoftwareApplication",
           "name": "TRAIL",
@@ -1665,7 +1677,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 137,
+        "position": 138,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Langfuse",
@@ -1677,7 +1689,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 138,
+        "position": 139,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MLflow",
@@ -1689,7 +1701,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 139,
+        "position": 140,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Opik",
@@ -1701,7 +1713,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 140,
+        "position": 141,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Arize Phoenix",
@@ -1713,7 +1725,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 141,
+        "position": 142,
         "item": {
           "@type": "SoftwareApplication",
           "name": "DeerFlow",
@@ -1725,7 +1737,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 142,
+        "position": 143,
         "item": {
           "@type": "SoftwareApplication",
           "name": "gpt-researcher",
@@ -1737,7 +1749,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 143,
+        "position": 144,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoResearchClaw",
@@ -1749,7 +1761,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 144,
+        "position": 145,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MiroThinker",
@@ -1761,7 +1773,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 145,
+        "position": 146,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openagents",
@@ -1773,7 +1785,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 146,
+        "position": 147,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Daytona",
@@ -1785,7 +1797,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 147,
+        "position": 148,
         "item": {
           "@type": "SoftwareApplication",
           "name": "LiteLLM",
@@ -1797,7 +1809,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 148,
+        "position": 149,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Composio",
@@ -1809,7 +1821,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 149,
+        "position": 150,
         "item": {
           "@type": "SoftwareApplication",
           "name": "smolagents",
@@ -1821,7 +1833,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 150,
+        "position": 151,
         "item": {
           "@type": "SoftwareApplication",
           "name": "deepagents",
@@ -1833,7 +1845,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 151,
+        "position": 152,
         "item": {
           "@type": "SoftwareApplication",
           "name": "vercel/ai",
@@ -1845,7 +1857,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 152,
+        "position": 153,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pydantic-ai",
@@ -1857,7 +1869,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 153,
+        "position": 154,
         "item": {
           "@type": "SoftwareApplication",
           "name": "E2B",
@@ -1869,7 +1881,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 154,
+        "position": 155,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Steel",
@@ -1881,7 +1893,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 155,
+        "position": 156,
         "item": {
           "@type": "SoftwareApplication",
           "name": "strands-agents",
@@ -1893,7 +1905,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 156,
+        "position": 157,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Cloudflare Agents",
@@ -1905,7 +1917,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 157,
+        "position": 158,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-js",
@@ -1917,7 +1929,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 158,
+        "position": 159,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Sandbox",
@@ -1929,7 +1941,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 159,
+        "position": 160,
         "item": {
           "@type": "SoftwareApplication",
           "name": "open-harness",
@@ -1941,7 +1953,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 160,
+        "position": 161,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Community-curated agent lists",

--- a/landscape.md
+++ b/landscape.md
@@ -1,6 +1,6 @@
 # The agent harness landscape, in two charts
 
-Both charts plot every project in [best-of-Agent-Harnesses](README.md), a curated list of 160 agent harnesses: the runtimes that turn an AI model into a working agent. They regenerate from the list data on every weekly refresh, so what you see is current.
+Both charts plot every project in [best-of-Agent-Harnesses](README.md), a curated list of 161 agent harnesses: the runtimes that turn an AI model into a working agent. They regenerate from the list data on every weekly refresh, so what you see is current.
 
 ## Adoption surface vs. stars
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Best of Agent Harnesses
 
-> Hand-curated, ranked list of 160 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 12 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-09-06.
+> Hand-curated, ranked list of 161 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 12 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-09-06.
 
 Maintained at https://github.com/RyanAlberts/best-of-Agent-Harnesses (CC-BY-SA-4.0).
 Structured data: https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses/main/harnesses.json
@@ -90,7 +90,7 @@ Harnesses designed for unattended runs, batches, and fleets: opencode, OpenHands
 Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n, langgraph, mastra, letta, deepagents, pydantic-ai, Cloudflare Agents.
 
 ### How many of these agent harnesses are open source?
-118 of 160 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+119 of 161 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 The runtime that turns a model into an agent: it decides what the model's reasoning is allowed to touch, and supplies the orchestration, tool wiring, memory, error recovery, and guardrails around per-turn inference.
@@ -114,7 +114,7 @@ Formats, runtimes, and patterns that reveal context, tools, or instructions in l
 - [ToolGen](https://github.com/Reason-Wang/ToolGen) — ⭐184, complex, autonomy: n/a, recovery: n/a, unknown: ICLR 2025: unified tool retrieval and calling via generation; 47k+ tools without context stuffing—retrieval and invocation in one generative step. [tool-discovery, python]
 - [ToolRAG](https://github.com/antl3x/ToolRAG) — ⭐33, mostly simple, autonomy: n/a, recovery: n/a, open-source: Semantic tool retrieval for LLMs; serves only the tools the user query demands (MCP-compatible), unlimited tool sets with zero context penalty. [mcp, tool-discovery]
 
-## Coding agent products (IDEs, CLIs, full suites) (22 projects)
+## Coding agent products (IDEs, CLIs, full suites) (23 projects)
 
 Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Dockerized workspaces. Each entry notes which part is the harness (the agent loop, tool wiring, approval model) versus the UI shell (VS Code extension, TUI, browser client).
 
@@ -140,6 +140,7 @@ Turnkey coding agents you install and run: IDE extensions, terminal CLIs, Docker
 - [claw-code-agent](https://github.com/HarnessLab/claw-code-agent) — ⭐544, slightly complex, autonomy: checkpoint-gated, recovery: none, unknown: Python reimplementation of the Claude Code agent architecture with zero external dependencies; interactive chat, streaming, plugin runtime, nested agent delegation, cost tracking, MCP transport—portable harness without the Rust/TS toolchain. [mcp, rust, python, typescript]
 - [Proliferate](https://github.com/proliferate-ai/proliferate) — ⭐463, complex, autonomy: bounded, recovery: resumable, open-source: Open-source AI IDE for Claude Code, Codex, OpenCode, and more. The **harness** contribution is the workspace/session orchestration layer: run multiple coding agents in parallel, locally or in the cloud, with isolated workspaces, reusable workflows, and shared team context. [multi-agent, sandbox, ide, typescript]
 - [AgentBox](https://github.com/madarco/agentbox) — ⭐387, slightly complex, autonomy: n/a, recovery: n/a, open-source: Runs multiple coding agents in parallel, each in its own sandboxed VM, locally or in the cloud, from one command. The **harness** contribution is the VM-per-agent isolation and fleet fan-out layer; whichever agent runs inside owns the loop. [sandbox, typescript]
+- [YYLO](https://github.com/yylo-dev/yylo) — ⭐57, slightly complex, autonomy: n/a, recovery: n/a, open-source: Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself. [multi-agent, typescript]
 
 ## Coding harness configs and SDKs (17 projects)
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -165,6 +165,10 @@ projects:
     github_id: NanmiCoder/cc-haha
     labels: ["javascript"]
     category: "coding-agent-products"
+  - name: YYLO
+    github_id: yylo-dev/yylo
+    labels: ["javascript"]
+    category: "coding-agent-products"
   # Coding harness configs and SDKs
   - name: LoopTroop
     github_id: looptroop-ai/LoopTroop

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -243,6 +243,9 @@ PROJECTS: dict[str, list[Project]] = {
         Project("cc-haha", "NanmiCoder/cc-haha",
                 "Local-first desktop workspace **harness** for Claude Code and other agents: multi-agent sessions, Git worktrees, code diffs, a skill marketplace, and chat-app access (WeChat, Telegram, WhatsApp).",
                 "complex (desktop workspace, multi-agent — product suite)", oss="❓", labels=["javascript"]),
+        Project("YYLO", "yylo-dev/yylo",
+                "Command-line orchestrator for coding agents (drives Pi and Codex subagents): every task gets a dedicated branch/worktree and a typed lifecycle — read-only preflight, risk-scaled merge-queue review, release-readiness gates — with receipt-backed changes. The **harness** contribution is the git-native task/merge orchestration layer on top of whichever agent executes; not an agent loop itself.",
+                "slightly complex (git-native task fleet, merge queue)", labels=["javascript"]),
     ],
     "coding-harness-configs": [
         Project("LoopTroop", "looptroop-ai/LoopTroop",
@@ -704,6 +707,7 @@ META: dict[str, tuple[int, str, str]] = {
     "esengine/DeepSeek-Reasonix": (35420, "https://github.com/esengine/DeepSeek-Reasonix#readme", "Project README"),
     "1jehuang/jcode": (19216, "https://github.com/1jehuang/jcode#readme", "Project README"),
     "NanmiCoder/cc-haha": (14286, "https://github.com/NanmiCoder/cc-haha#readme", "Project README"),
+    "yylo-dev/yylo": (57, "https://github.com/yylo-dev/yylo#readme", "Project README"),
     # coding-harness-configs
     "looptroop-ai/LoopTroop": (130, "https://github.com/looptroop-ai/LoopTroop#readme", "Council → loop → worktree pipeline"),
     "open-gsd/gsd-core": (9153, "https://github.com/open-gsd/gsd-core/blob/next/commands/gsd/ship.md", "gsd:ship command"),
@@ -1076,6 +1080,7 @@ AXES: "dict[str, tuple[str, str]]" = {
     "esengine/DeepSeek-Reasonix": ("n/a", "n/a"),
     "1jehuang/jcode": ("n/a", "n/a"),
     "NanmiCoder/cc-haha": ("n/a", "n/a"),
+    "yylo-dev/yylo": ("n/a", "n/a"),  # orchestrates Pi/Codex loops; doesn't own one
     # coding-harness-configs
     "looptroop-ai/LoopTroop": ("bounded", "retry"),
     "obra/superpowers": ("n/a", "n/a"),


### PR DESCRIPTION
## Summary
- add YYLO to coding agent products — a command-line orchestrator for coding agents (drives Pi and Codex subagents): dedicated branch/worktree per task, typed task lifecycle (read-only preflight, risk-scaled merge-queue review, release-readiness gates), receipt-backed changes. MIT-licensed, 57 stars, on npm as `@yylo/cli`, actively maintained (daily commits since Jan 2026).
- adds the three required `generate.py` entries (PROJECTS / META / AXES, `n/a` axes — it orchestrates agent loops rather than owning one, like vibe-kanban/AgentBox) and regenerates every managed artifact.

## Validation
- `python3 scripts/generate.py`
- `python3 -m pytest tests/ -q` → 54 passed

## Notes
- happy to rebase if the weekly rescore or another add lands first — all generated artifacts are fully reproducible from `generate.py`.
- if 57 stars doesn't clear the bar yet, the radar section is a fine landing spot — happy to reshape the PR that way.

## Disclosure
- I'm on the YYLO team; this PR was prepared with AI assistance and every claim above is checkable against the repo (license, stars, npm, commit history).