### PR TITLE
Add project: Gram

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-164-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-165-blue.svg?color=5ac4bf"></a>
     <a href="#for-agents" title="Agents can query this list — MCP server, llms.txt & JSON"><img src="https://img.shields.io/badge/agents-query%20this%20list-5ac4bf.svg"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
@@ -121,7 +121,7 @@ curl -fsSL https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses
 - [Personal agent runtimes](#personal-agent-runtimes) _11 projects_
 - [Frameworks](#frameworks) _26 projects_
 - [Multi-agent and orchestration](#multi-agent-and-orchestration) _12 projects_
-- [Plugins, MCPs, CLI tools](#plugins-mcps-cli-tools) _19 projects_
+- [Plugins, MCPs, CLI tools](#plugins-mcps-cli-tools) _20 projects_
 - [Memory and state](#memory-and-state) _5 projects_
 - [Evaluation and benchmarking harnesses](#evaluation-and-benchmarking-harnesses) _19 projects_
 - [Observability and eval-ops](#observability-and-eval-ops) _4 projects_
@@ -317,9 +317,10 @@ _IDE plugins, concrete MCP servers, and CLI tools that give agents tools and con
 | 14 | <a name="cocoindex-code"></a>[**cocoindex-code**](https://github.com/cocoindex-io/cocoindex-code) | [2.7k](https://github.com/cocoindex-io/cocoindex-code/stargazers) | Embedded, tree-sitter/AST-based code-search CLI and MCP server that gives coding agents fast semantic lookups over a repo instead of grepping or re-reading whole files into context. <sup>`mcp` · `cli`</sup> | ❓ | mostly simple (embedded CLI + MCP server) | [Project README](https://github.com/cocoindex-io/cocoindex-code#readme) |
 | 15 | <a name="agent-vault"></a>[**agent-vault**](https://github.com/Infisical/agent-vault) | [2.2k](https://github.com/Infisical/agent-vault/stargazers) | Infisical's HTTP credential proxy that fronts secrets for Claude Code, OpenClaw, and other agent harnesses so the agent's tool calls never see raw credentials—a **harness** security layer, not an agent loop itself. | ❓ | mostly simple (credential proxy) | [Project README](https://github.com/Infisical/agent-vault#readme) |
 | 16 | <a name="mcp-gateway"></a>[**Docker MCP Gateway**](https://github.com/docker/mcp-gateway) | [1.6k](https://github.com/docker/mcp-gateway/stargazers) | Docker's official MCP CLI plugin / gateway; container-aware MCP tooling from Docker (replaces deprecated `docker/mcp-servers` path). <sup>`mcp` · `sandbox` · `cli`</sup> | ✅ | slightly complex (Docker-aware MCPs) | [Gateway usage walkthrough](https://github.com/docker/mcp-gateway/blob/main/docs/mcp-gateway.md) |
-| 17 | <a name="puppeteer-real-browser-mcp-server"></a>[**puppeteer-real-browser-mcp**](https://github.com/withLinda/puppeteer-real-browser-mcp-server) | [26](https://github.com/withLinda/puppeteer-real-browser-mcp-server/stargazers) | Puppeteer MCP with real-browser and anti-detection; for agents that need to drive sites that block headless. <sup>`mcp` · `browser` · `typescript`</sup> | ❓ | mostly simple (real browser, anti-detect) | [11 anti-detection tools](https://github.com/withLinda/puppeteer-real-browser-mcp-server/blob/main/README.md) |
-| 18 | <a name="better-opencodemcp"></a>[**Better-OpenCodeMCP**](https://github.com/ajhcs/Better-OpenCodeMCP) | [9](https://github.com/ajhcs/Better-OpenCodeMCP/stargazers) | MCP server for OpenCode/Crush: async task execution, model bridging (e.g. Claude→Gemini), process pooling. <sup>`mcp` · `typescript`</sup> | ✅ | mostly simple (MCP server, model bridging) | [opencode delegate tool](https://github.com/ajhcs/Better-OpenCodeMCP/blob/main/src/tools/opencode.tool.ts) |
-| 19 | <a name="agentlog"></a>[**agentlog**](https://github.com/RyanAlberts/agentlog) | [1](https://github.com/RyanAlberts/agentlog/stargazers) | Persistent decision memory for any project: `remember`, `recall`, `reflect`. Single-file Python CLI that stores decisions as JSONL and uses Claude or Gemini to retrieve and synthesize patterns—Karpathy's LLM Wiki concept as a CLI. <sup>`memory` · `cli` · `python`</sup> | ✅ | super simple (one file, three commands) | [Sample decisions.jsonl](https://github.com/RyanAlberts/agentlog/blob/main/example-log/decisions.jsonl) |
+| 17 | <a name="gram"></a>[**Gram**](https://github.com/speakeasy-api/gram) | [266](https://github.com/speakeasy-api/gram/stargazers) | Open-source AI control plane that connects agents to MCPs, Skills, Plugins, and Assistants. Its **harness** contribution is the policy and tool-wiring layer: role-scoped team, server, and tool permissions determine which connections an agent can use; it does not own the agent loop. <sup>`mcp`</sup> | ✅ | slightly complex (MCP control plane, role-scoped access) | [AI control plane documentation](https://www.speakeasy.com/docs/ai-control-plane) |
+| 18 | <a name="puppeteer-real-browser-mcp-server"></a>[**puppeteer-real-browser-mcp**](https://github.com/withLinda/puppeteer-real-browser-mcp-server) | [26](https://github.com/withLinda/puppeteer-real-browser-mcp-server/stargazers) | Puppeteer MCP with real-browser and anti-detection; for agents that need to drive sites that block headless. <sup>`mcp` · `browser` · `typescript`</sup> | ❓ | mostly simple (real browser, anti-detect) | [11 anti-detection tools](https://github.com/withLinda/puppeteer-real-browser-mcp-server/blob/main/README.md) |
+| 19 | <a name="better-opencodemcp"></a>[**Better-OpenCodeMCP**](https://github.com/ajhcs/Better-OpenCodeMCP) | [9](https://github.com/ajhcs/Better-OpenCodeMCP/stargazers) | MCP server for OpenCode/Crush: async task execution, model bridging (e.g. Claude→Gemini), process pooling. <sup>`mcp` · `typescript`</sup> | ✅ | mostly simple (MCP server, model bridging) | [opencode delegate tool](https://github.com/ajhcs/Better-OpenCodeMCP/blob/main/src/tools/opencode.tool.ts) |
+| 20 | <a name="agentlog"></a>[**agentlog**](https://github.com/RyanAlberts/agentlog) | [1](https://github.com/RyanAlberts/agentlog/stargazers) | Persistent decision memory for any project: `remember`, `recall`, `reflect`. Single-file Python CLI that stores decisions as JSONL and uses Claude or Gemini to retrieve and synthesize patterns—Karpathy's LLM Wiki concept as a CLI. <sup>`memory` · `cli` · `python`</sup> | ✅ | super simple (one file, three commands) | [Sample decisions.jsonl](https://github.com/RyanAlberts/agentlog/blob/main/example-log/decisions.jsonl) |
 
 ## Memory and state
 
@@ -467,7 +468,7 @@ Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n
 
 ### How many of these agent harnesses are open source?
 
-121 of 164 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+122 of 165 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable -->
 # Tags — cross-reference
 
-_Auto-generated from `scripts/generate.py`. 164 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
+_Auto-generated from `scripts/generate.py`. 165 projects across 22 canonical tags. Edit projects in `generate.py` (not here) and rerun the script._
 
 Tag chips appear next to each project in [README.md](README.md). This page lists every tag once with the projects that carry it, grouped by category and sorted by GitHub stars within each category.
 
 ## All tags
 
-[`mcp`](#mcp) (33) · [`memory`](#memory) (35) · [`multi-agent`](#multi-agent) (28) · [`evals`](#evals) (22) · [`voice`](#voice) (2) · [`vision`](#vision) (4) · [`browser`](#browser) (9) · [`sandbox`](#sandbox) (28) · [`low-code`](#low-code) (4) · [`rag`](#rag) (9) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (5) · [`workflow`](#workflow) (10) · [`typed`](#typed) (3) · [`local`](#local) (6) · [`provider-agnostic`](#provider-agnostic) (11) · [`cli`](#cli) (22) · [`ide`](#ide) (13) · [`tui`](#tui) (4) · [`rust`](#rust) (5) · [`python`](#python) (80) · [`typescript`](#typescript) (43)
+[`mcp`](#mcp) (34) · [`memory`](#memory) (35) · [`multi-agent`](#multi-agent) (28) · [`evals`](#evals) (22) · [`voice`](#voice) (2) · [`vision`](#vision) (4) · [`browser`](#browser) (9) · [`sandbox`](#sandbox) (28) · [`low-code`](#low-code) (4) · [`rag`](#rag) (9) · [`tool-discovery`](#tool-discovery) (5) · [`training`](#training) (5) · [`workflow`](#workflow) (10) · [`typed`](#typed) (3) · [`local`](#local) (6) · [`provider-agnostic`](#provider-agnostic) (11) · [`cli`](#cli) (22) · [`ide`](#ide) (13) · [`tui`](#tui) (4) · [`rust`](#rust) (5) · [`python`](#python) (80) · [`typescript`](#typescript) (43)
 
 ---
 
@@ -57,6 +57,7 @@ Tag chips appear next to each project in [README.md](README.md). This page lists
 - [mcp-context-forge](https://github.com/IBM/mcp-context-forge) — ⭐4.4k — IBM's official AI gateway/registry/proxy that sits in front of any MCP, A2A, or REST/gRPC API: unified endpoint, centralized discovery, guardrails, and plugin support—the enterprise front door for **harness** tool calling. Graduated off the radar this cycle.
 - [cocoindex-code](https://github.com/cocoindex-io/cocoindex-code) — ⭐2.7k — Embedded, tree-sitter/AST-based code-search CLI and MCP server that gives coding agents fast semantic lookups over a repo instead of grepping or re-reading whole files into context.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) — ⭐1.6k — Docker's official MCP CLI plugin / gateway; container-aware MCP tooling from Docker (replaces deprecated `docker/mcp-servers` path).
+- [Gram](https://github.com/speakeasy-api/gram) — ⭐266 — Open-source AI control plane that connects agents to MCPs, Skills, Plugins, and Assistants. Its **harness** contribution is the policy and tool-wiring layer: role-scoped team, server, and tool permissions determine which connections an agent can use; it does not own the agent loop.
 - [puppeteer-real-browser-mcp](https://github.com/withLinda/puppeteer-real-browser-mcp-server) — ⭐26 — Puppeteer MCP with real-browser and anti-detection; for agents that need to drive sites that block headless.
 - [Better-OpenCodeMCP](https://github.com/ajhcs/Better-OpenCodeMCP) — ⭐9 — MCP server for OpenCode/Crush: async task execution, model bridging (e.g. Claude→Gemini), process pooling.
 

--- a/assets/axes-grid.svg
+++ b/assets/axes-grid.svg
@@ -143,5 +143,5 @@
 <text x="993.7" y="164.6" text-anchor="end" font-size="12.5" font-weight="600" fill="#1f2937">n8n</text>
 <text x="913.1" y="500.7" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">Dify</text>
 <text x="534.2" y="313.2" text-anchor="start" font-size="12.5" font-weight="600" fill="#1f2937">aider</text>
-<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">98 loop-owning projects shown · 66 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
+<text x="1060" y="784" text-anchor="end" font-size="12" fill="#9ca3af">98 loop-owning projects shown · 67 format/component entries (n/a) omitted · full tiers in harnesses.json</text>
 </svg>

--- a/assets/landscape.svg
+++ b/assets/landscape.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 880" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
 <rect width="1320" height="880" fill="#ffffff" rx="8"/>
 <text x="660.0" y="52" text-anchor="middle" font-size="30" font-weight="700" fill="#111827">The Agent Harness Landscape</text>
-<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">164 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-09-09</text>
+<text x="660.0" y="80" text-anchor="middle" font-size="15" fill="#6b7280">165 hand-curated projects · GitHub stars vs. adoption surface area · stars captured 2026-09-09</text>
 <circle cx="80" cy="106" r="6" fill="#8b5cf6"/>
 <text x="91" y="110" font-size="12.5" fill="#374151">Progressive disclosure</text>
 <circle cx="262.2" cy="106" r="6" fill="#ef4444"/>
@@ -44,7 +44,7 @@
 <text x="533.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">33 projects</text>
 <line x1="685.0" y1="168" x2="685.0" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="836.2" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">slightly complex</text>
-<text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">66 projects</text>
+<text x="836.2" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">67 projects</text>
 <line x1="987.5" y1="168" x2="987.5" y2="750" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="1138.8" y="780" text-anchor="middle" font-size="15" font-weight="600" fill="#111827">complex</text>
 <text x="1138.8" y="800" text-anchor="middle" font-size="12" fill="#9ca3af">53 projects</text>
@@ -66,6 +66,7 @@
 <circle cx="1213.3" cy="528.5" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>VitaBench — ⭐174</title></circle>
 <circle cx="1139.9" cy="525.8" r="4.5" fill="#8b5cf6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>ToolGen — ⭐184</title></circle>
 <circle cx="523.7" cy="520.7" r="4.5" fill="#3b82f6" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>SuperAgentX — ⭐204</title></circle>
+<circle cx="864.1" cy="507.5" r="4.5" fill="#10b981" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>Gram — ⭐266</title></circle>
 <circle cx="1057.2" cy="493.8" r="4.5" fill="#ec4899" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>AgentRL — ⭐351</title></circle>
 <circle cx="559.5" cy="492.2" r="4.5" fill="#64748b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>arc-agi-benchmarking — ⭐362</title></circle>
 <circle cx="295.1" cy="490.9" r="4.5" fill="#f59e0b" fill-opacity="0.85" stroke="#ffffff" stroke-width="1.2"><title>AutoHarness — ⭐372</title></circle>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -5,6 +5,6 @@
   <text x="140" y="184" font-family="Helvetica,Arial,sans-serif" font-size="32" fill="#5ac4bf" font-weight="700">best-of-Agent-Harnesses</text>
   <text x="80" y="300" font-family="Helvetica,Arial,sans-serif" font-size="74" fill="#f0f6fc" font-weight="800">Best of Agent Harnesses</text>
   <text x="80" y="378" font-family="Helvetica,Arial,sans-serif" font-size="38" fill="#9ca3af">The runtimes that close the loop between a model and the world.</text>
-  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">164 harnesses · 12 categories · MCP-ready · weekly-rescored</text>
+  <text x="80" y="500" font-family="Helvetica,Arial,sans-serif" font-size="36" fill="#f0f6fc" font-weight="600">165 harnesses · 12 categories · MCP-ready · weekly-rescored</text>
   <text x="80" y="566" font-family="Helvetica,Arial,sans-serif" font-size="27" fill="#9ca3af">github.com/RyanAlberts/best-of-Agent-Harnesses</text>
 </svg>

--- a/config/header.md
+++ b/config/header.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-164-blue.svg?color=5ac4bf"></a>
+    <a href="#contents" title="Project Count"><img src="https://img.shields.io/badge/projects-165-blue.svg?color=5ac4bf"></a>
     <a href="#contribution" title="Contributions welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/RyanAlberts/best-of-Agent-Harnesses/commits/main" title="Updates"><img src="https://img.shields.io/github/last-commit/RyanAlberts/best-of-Agent-Harnesses?color=green&label=updated"></a>
 </p>

--- a/feed.json
+++ b/feed.json
@@ -16,7 +16,7 @@
       "title": "Agent Harnesses list refreshed — 2026-09-09",
       "url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses",
       "date_published": "2026-09-09T00:00:00Z",
-      "content_text": "164 harnesses across 12 categories. Stars captured 2026-09-09. Most-starred: Headroom, awesome-cursorrules, agents.md, context-mode, langgraph-bigtool."
+      "content_text": "165 harnesses across 12 categories. Stars captured 2026-09-09. Most-starred: Headroom, awesome-cursorrules, agents.md, context-mode, langgraph-bigtool."
     },
     {
       "id": "refresh-2026-09-06",

--- a/harnesses.json
+++ b/harnesses.json
@@ -9,7 +9,7 @@
     "feed_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/feed.json",
     "license": "CC-BY-SA-4.0",
     "stars_captured": "2026-09-09",
-    "project_count": 164,
+    "project_count": 165,
     "graveyard_count": 3,
     "tiers": [
       "super simple",
@@ -375,7 +375,7 @@
     {
       "kind": "derived",
       "q": "How many of these agent harnesses are open source?",
-      "a": "121 of 164 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
+      "a": "122 of 165 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.",
       "slug": "how-many-of-these-agent-harnesses-are-open-source"
     },
     {
@@ -6384,6 +6384,34 @@
       "example": {
         "label": "Gateway usage walkthrough",
         "url": "https://github.com/docker/mcp-gateway/blob/main/docs/mcp-gateway.md"
+      },
+      "deep_dive": null
+    },
+    {
+      "name": "Gram",
+      "github_id": "speakeasy-api/gram",
+      "url": "https://github.com/speakeasy-api/gram",
+      "slug": "gram",
+      "anchor_url": "https://github.com/RyanAlberts/best-of-Agent-Harnesses#gram",
+      "page_url": "https://ryanalberts.github.io/best-of-Agent-Harnesses/h/gram/",
+      "description": "Open-source AI control plane that connects agents to MCPs, Skills, Plugins, and Assistants. Its **harness** contribution is the policy and tool-wiring layer: role-scoped team, server, and tool permissions determine which connections an agent can use; it does not own the agent loop.",
+      "category": "plugins-mcp-cli",
+      "category_title": "Plugins, MCPs, CLI tools",
+      "stars": 266,
+      "tier": "slightly complex",
+      "tier_rank": 3,
+      "axis": "slightly complex (MCP control plane, role-scoped access)",
+      "autonomy": "n/a",
+      "autonomy_rank": 0,
+      "recovery": "n/a",
+      "recovery_rank": 0,
+      "license_signal": "open-source",
+      "tags": [
+        "mcp"
+      ],
+      "example": {
+        "label": "AI control plane documentation",
+        "url": "https://www.speakeasy.com/docs/ai-control-plane"
       },
       "deep_dive": null
     },

--- a/harnesses.jsonld
+++ b/harnesses.jsonld
@@ -29,7 +29,7 @@
   ],
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": 164,
+    "numberOfItems": 165,
     "itemListElement": [
       {
         "@type": "ListItem",
@@ -1392,6 +1392,18 @@
         "position": 114,
         "item": {
           "@type": "SoftwareApplication",
+          "name": "Gram",
+          "url": "https://github.com/speakeasy-api/gram",
+          "description": "Open-source AI control plane that connects agents to MCPs, Skills, Plugins, and Assistants. Its **harness** contribution is the policy and tool-wiring layer: role-scoped team, server, and tool permissions determine which connections an agent can use; it does not own the agent loop.",
+          "applicationCategory": "DeveloperApplication",
+          "keywords": "mcp"
+        }
+      },
+      {
+        "@type": "ListItem",
+        "position": 115,
+        "item": {
+          "@type": "SoftwareApplication",
           "name": "puppeteer-real-browser-mcp",
           "url": "https://github.com/withLinda/puppeteer-real-browser-mcp-server",
           "description": "Puppeteer MCP with real-browser and anti-detection; for agents that need to drive sites that block headless.",
@@ -1401,7 +1413,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 115,
+        "position": 116,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Better-OpenCodeMCP",
@@ -1413,7 +1425,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 116,
+        "position": 117,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agentlog",
@@ -1425,7 +1437,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 117,
+        "position": 118,
         "item": {
           "@type": "SoftwareApplication",
           "name": "claude-mem",
@@ -1437,7 +1449,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 118,
+        "position": 119,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Mem0",
@@ -1449,7 +1461,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 119,
+        "position": 120,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Graphiti (Zep)",
@@ -1461,7 +1473,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 120,
+        "position": 121,
         "item": {
           "@type": "SoftwareApplication",
           "name": "cognee",
@@ -1473,7 +1485,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 121,
+        "position": 122,
         "item": {
           "@type": "SoftwareApplication",
           "name": "beads",
@@ -1485,7 +1497,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 122,
+        "position": 123,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Lightning",
@@ -1497,7 +1509,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 123,
+        "position": 124,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-bench",
@@ -1509,7 +1521,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 124,
+        "position": 125,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgentBench",
@@ -1521,7 +1533,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 125,
+        "position": 126,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_ai",
@@ -1533,7 +1545,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 126,
+        "position": 127,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebArena",
@@ -1545,7 +1557,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 127,
+        "position": 128,
         "item": {
           "@type": "SoftwareApplication",
           "name": "WebVoyager",
@@ -1557,7 +1569,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 128,
+        "position": 129,
         "item": {
           "@type": "SoftwareApplication",
           "name": "agent-qa",
@@ -1569,7 +1581,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 129,
+        "position": 130,
         "item": {
           "@type": "SoftwareApplication",
           "name": "swe-smith",
@@ -1581,7 +1593,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 130,
+        "position": 131,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ARC-AGI-2",
@@ -1593,7 +1605,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 131,
+        "position": 132,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SWE-Gym",
@@ -1605,7 +1617,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 132,
+        "position": 133,
         "item": {
           "@type": "SoftwareApplication",
           "name": "ClawBench",
@@ -1617,7 +1629,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 133,
+        "position": 134,
         "item": {
           "@type": "SoftwareApplication",
           "name": "inspect_evals",
@@ -1629,7 +1641,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 134,
+        "position": 135,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Terminal-Bench",
@@ -1641,7 +1653,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 135,
+        "position": 136,
         "item": {
           "@type": "SoftwareApplication",
           "name": "arc-agi-benchmarking",
@@ -1653,7 +1665,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 136,
+        "position": 137,
         "item": {
           "@type": "SoftwareApplication",
           "name": "VitaBench",
@@ -1665,7 +1677,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 137,
+        "position": 138,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AgencyBench",
@@ -1677,7 +1689,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 138,
+        "position": 139,
         "item": {
           "@type": "SoftwareApplication",
           "name": "letta-evals",
@@ -1689,7 +1701,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 139,
+        "position": 140,
         "item": {
           "@type": "SoftwareApplication",
           "name": "SUPER",
@@ -1701,7 +1713,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 140,
+        "position": 141,
         "item": {
           "@type": "SoftwareApplication",
           "name": "TRAIL",
@@ -1713,7 +1725,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 141,
+        "position": 142,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Langfuse",
@@ -1725,7 +1737,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 142,
+        "position": 143,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MLflow",
@@ -1737,7 +1749,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 143,
+        "position": 144,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Opik",
@@ -1749,7 +1761,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 144,
+        "position": 145,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Arize Phoenix",
@@ -1761,7 +1773,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 145,
+        "position": 146,
         "item": {
           "@type": "SoftwareApplication",
           "name": "DeerFlow",
@@ -1773,7 +1785,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 146,
+        "position": 147,
         "item": {
           "@type": "SoftwareApplication",
           "name": "gpt-researcher",
@@ -1785,7 +1797,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 147,
+        "position": 148,
         "item": {
           "@type": "SoftwareApplication",
           "name": "AutoResearchClaw",
@@ -1797,7 +1809,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 148,
+        "position": 149,
         "item": {
           "@type": "SoftwareApplication",
           "name": "MiroThinker",
@@ -1809,7 +1821,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 149,
+        "position": 150,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openagents",
@@ -1821,7 +1833,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 150,
+        "position": 151,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Daytona",
@@ -1833,7 +1845,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 151,
+        "position": 152,
         "item": {
           "@type": "SoftwareApplication",
           "name": "LiteLLM",
@@ -1845,7 +1857,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 152,
+        "position": 153,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Composio",
@@ -1857,7 +1869,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 153,
+        "position": 154,
         "item": {
           "@type": "SoftwareApplication",
           "name": "smolagents",
@@ -1869,7 +1881,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 154,
+        "position": 155,
         "item": {
           "@type": "SoftwareApplication",
           "name": "deepagents",
@@ -1881,7 +1893,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 155,
+        "position": 156,
         "item": {
           "@type": "SoftwareApplication",
           "name": "vercel/ai",
@@ -1893,7 +1905,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 156,
+        "position": 157,
         "item": {
           "@type": "SoftwareApplication",
           "name": "pydantic-ai",
@@ -1905,7 +1917,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 157,
+        "position": 158,
         "item": {
           "@type": "SoftwareApplication",
           "name": "E2B",
@@ -1917,7 +1929,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 158,
+        "position": 159,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Steel",
@@ -1929,7 +1941,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 159,
+        "position": 160,
         "item": {
           "@type": "SoftwareApplication",
           "name": "strands-agents",
@@ -1941,7 +1953,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 160,
+        "position": 161,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Cloudflare Agents",
@@ -1953,7 +1965,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 161,
+        "position": 162,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Agent Sandbox",
@@ -1965,7 +1977,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 162,
+        "position": 163,
         "item": {
           "@type": "SoftwareApplication",
           "name": "openai-agents-js",
@@ -1977,7 +1989,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 163,
+        "position": 164,
         "item": {
           "@type": "SoftwareApplication",
           "name": "open-harness",
@@ -1989,7 +2001,7 @@
       },
       {
         "@type": "ListItem",
-        "position": 164,
+        "position": 165,
         "item": {
           "@type": "SoftwareApplication",
           "name": "Community-curated agent lists",

--- a/landscape.md
+++ b/landscape.md
@@ -1,6 +1,6 @@
 # The agent harness landscape, in two charts
 
-Both charts plot every project in [best-of-Agent-Harnesses](README.md), a curated list of 164 agent harnesses: the runtimes that turn an AI model into a working agent. They regenerate from the list data on every weekly refresh, so what you see is current.
+Both charts plot every project in [best-of-Agent-Harnesses](README.md), a curated list of 165 agent harnesses: the runtimes that turn an AI model into a working agent. They regenerate from the list data on every weekly refresh, so what you see is current.
 
 ## Adoption surface vs. stars
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Best of Agent Harnesses
 
-> Hand-curated, ranked list of 164 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 12 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-09-09.
+> Hand-curated, ranked list of 165 AI agent harnesses — the runtimes that close the loop between a stateless model and the outside world. 12 categories, a 4-tier adoption-surface rating (simplicity ↔ capability), capability tags, a license signal, and one concrete example link per project. Stars captured 2026-09-09.
 
 Maintained at https://github.com/RyanAlberts/best-of-Agent-Harnesses (CC-BY-SA-4.0).
 Structured data: https://raw.githubusercontent.com/RyanAlberts/best-of-Agent-Harnesses/main/harnesses.json
@@ -90,7 +90,7 @@ Harnesses designed for unattended runs, batches, and fleets: opencode, OpenHands
 Harnesses whose execution state persists across restarts: langgraph-bigtool, n8n, langgraph, mastra, letta, deepagents, pydantic-ai, Cloudflare Agents.
 
 ### How many of these agent harnesses are open source?
-121 of 164 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
+122 of 165 carry a standard open-source license; the rest are source-available or unclear, and flagged per row.
 
 ### What is an agent harness?
 The runtime that turns a model into an agent: it decides what the model's reasoning is allowed to touch, and supplies the orchestration, tool wiring, memory, error recovery, and guardrails around per-turn inference.
@@ -228,7 +228,7 @@ Harnesses and patterns for multi-agent coordination and handoffs.
 - [AG2](https://github.com/ag2ai/ag2) — ⭐4.9k, complex, autonomy: n/a, recovery: n/a, unknown: AG2 (formerly AutoGen): the community-governed continuation of the original AutoGen project after Microsoft's fork diverged—conversable multi-agent groups, code execution, and human-in-the-loop under an open-source AgentOS banner. Graduated off the radar this cycle. [multi-agent, python]
 - [AgentRL](https://github.com/THUDM/AgentRL) — ⭐351, complex, autonomy: headless, recovery: resumable, open-source: Multitask, multiturn RL for LLM agents; Ray-based scaling, rollout/actor workers—for teams that want to train agents, not just run them. [training, python]
 
-## Plugins, MCPs, CLI tools (19 projects)
+## Plugins, MCPs, CLI tools (20 projects)
 
 IDE plugins, concrete MCP servers, and CLI tools that give agents tools and context.
 
@@ -248,6 +248,7 @@ IDE plugins, concrete MCP servers, and CLI tools that give agents tools and cont
 - [cocoindex-code](https://github.com/cocoindex-io/cocoindex-code) — ⭐2.7k, mostly simple, autonomy: n/a, recovery: n/a, unknown: Embedded, tree-sitter/AST-based code-search CLI and MCP server that gives coding agents fast semantic lookups over a repo instead of grepping or re-reading whole files into context. [mcp, cli]
 - [agent-vault](https://github.com/Infisical/agent-vault) — ⭐2.2k, mostly simple, autonomy: n/a, recovery: n/a, unknown: Infisical's HTTP credential proxy that fronts secrets for Claude Code, OpenClaw, and other agent harnesses so the agent's tool calls never see raw credentials—a **harness** security layer, not an agent loop itself.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) — ⭐1.6k, slightly complex, autonomy: n/a, recovery: n/a, open-source: Docker's official MCP CLI plugin / gateway; container-aware MCP tooling from Docker (replaces deprecated `docker/mcp-servers` path). [mcp, sandbox, cli]
+- [Gram](https://github.com/speakeasy-api/gram) — ⭐266, slightly complex, autonomy: n/a, recovery: n/a, open-source: Open-source AI control plane that connects agents to MCPs, Skills, Plugins, and Assistants. Its **harness** contribution is the policy and tool-wiring layer: role-scoped team, server, and tool permissions determine which connections an agent can use; it does not own the agent loop. [mcp]
 - [puppeteer-real-browser-mcp](https://github.com/withLinda/puppeteer-real-browser-mcp-server) — ⭐26, mostly simple, autonomy: n/a, recovery: n/a, unknown: Puppeteer MCP with real-browser and anti-detection; for agents that need to drive sites that block headless. [mcp, browser, typescript]
 - [Better-OpenCodeMCP](https://github.com/ajhcs/Better-OpenCodeMCP) — ⭐9, mostly simple, autonomy: n/a, recovery: n/a, open-source: MCP server for OpenCode/Crush: async task execution, model bridging (e.g. Claude→Gemini), process pooling. [mcp, typescript]
 - [agentlog](https://github.com/RyanAlberts/agentlog) — ⭐1, super simple, autonomy: n/a, recovery: n/a, open-source: Persistent decision memory for any project: `remember`, `recall`, `reflect`. Single-file Python CLI that stores decisions as JSONL and uses Claude or Gemini to retrieve and synthesize patterns—Karpathy's LLM Wiki concept as a CLI. [memory, cli, python]

--- a/projects.yaml
+++ b/projects.yaml
@@ -422,6 +422,9 @@ projects:
     labels: ["python"]
     category: "multi-agent"
   # Plugins, MCPs, CLI tools
+  - name: Gram
+    github_id: speakeasy-api/gram
+    category: "plugins-mcp-cli"
   - name: aider
     github_id: Aider-AI/aider
     labels: ["python"]

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -459,6 +459,9 @@ PROJECTS: dict[str, list[Project]] = {
                 "complex (meta-harness, policy + sandboxing — product suite)", oss="❓", labels=["python"]),
     ],
     "plugins-mcp-cli": [
+        Project("Gram", "speakeasy-api/gram",
+                "Open-source AI control plane that connects agents to MCPs, Skills, Plugins, and Assistants. Its **harness** contribution is the policy and tool-wiring layer: role-scoped team, server, and tool permissions determine which connections an agent can use; it does not own the agent loop.",
+                "slightly complex (MCP control plane, role-scoped access)"),
         Project("aider", "Aider-AI/aider",
                 "Git-aware CLI pair programmer; edits in-repo, supports multiple models and MCP so agents see version control and tools.",
                 "slightly complex (CLI, git-aware, MCP)", labels=["python"]),
@@ -784,6 +787,7 @@ META: dict[str, tuple[int, str, str]] = {
     "aden-hive/hive": (11024, "https://github.com/aden-hive/hive#readme", "Project README"),
     "omnigent-ai/omnigent": (9806, "https://github.com/omnigent-ai/omnigent#readme", "Project README"),
     # plugins-mcp-cli
+    "speakeasy-api/gram": (266, "https://www.speakeasy.com/docs/ai-control-plane", "AI control plane documentation"),
     "Aider-AI/aider": (48852, "https://github.com/Aider-AI/aider/blob/main/aider/repomap.py", "Repo map source"),
     "RyanAlberts/agentlog": (1, "https://github.com/RyanAlberts/agentlog/blob/main/example-log/decisions.jsonl", "Sample decisions.jsonl"),
     "thedotmack/claude-mem": (93568, "https://github.com/thedotmack/claude-mem/blob/main/plugin/hooks/hooks.json", "Lifecycle hooks config"),
@@ -1190,6 +1194,7 @@ AXES: "dict[str, tuple[str, str]]" = {
     "aden-hive/hive": ("bounded", "resumable"),
     "omnigent-ai/omnigent": ("n/a", "n/a"),
     # plugins-mcp-cli
+    "speakeasy-api/gram": ("n/a", "n/a"),
     "thedotmack/claude-mem": ("n/a", "n/a"),
     "Aider-AI/aider": ("checkpoint-gated", "resumable"),
     "continuedev/continue": ("checkpoint-gated", "resumable"),


### PR DESCRIPTION
**What kind of change is this?**

- [x] Add a project → fill in the intake below
- [ ] Correct a project I maintain (description / example link / tier / axes score)
- [ ] Scripts, site, docs, or CI
- [ ] Other:

**Description:**

Adds Gram to Plugins, MCPs, CLI tools and regenerates the derived catalog artifacts.

---

## Project intake (required when adding a project)

**The project**

- Repo URL: https://github.com/speakeasy-api/gram
- Proposed category: Plugins, MCPs, CLI tools
- One sentence on what the harness is: Gram provides the policy and tool-wiring layer around an existing agent loop, connecting agents to MCPs, Skills, Plugins, and Assistants with role-scoped team, server, and tool permissions.
- Closest existing entry on the list, and what this adds over it: Agent Governance Toolkit is a policy-enforcement layer; Gram adds centrally managed MCP connection and distribution controls with role-scoped access.
- Best show me it in action link: https://www.speakeasy.com/docs/ai-control-plane

**Disclosure**

- [x] I maintain or am affiliated with this project (I am affiliated with Speakeasy, which maintains Gram.)
- [ ] I am an unaffiliated user of it

**Quality self-check**

- [ ] It owns or structures an agent loop. Gram does not own the agent loop; it governs the MCP tool surface and policy boundary that an existing loop uses.
- [x] A LICENSE file exists: AGPL-3.0
- [x] Active within the last 60 days and not archived
- [x] Real usage signals: roughly 100+ stars and more than 10 commits
- [x] The README includes a local-development workflow
- [x] Not already on the list, the Graveyard, or the radar

**Mechanics**

- [x] Changes are in scripts/generate.py (PROJECTS + META + AXES), not in generated files
- [x] Ran python3 scripts/generate.py and committed regenerated outputs
- [x] python3 -m pytest tests/ -q passes (58 passed)